### PR TITLE
Fix table layout and add missing books

### DIFF
--- a/1-genesis.html
+++ b/1-genesis.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Genesis</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Genesis</h1>
+<p><strong>Author:</strong> Traditionally Moses</p>
+<p><strong>Date of Writing:</strong> around 1440-1400 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Genesis 1:1):</strong> In the beginning, God created the heavens and the earth.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 50</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 50.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 50;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/10-2-samuel.html
+++ b/10-2-samuel.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>2 Samuel</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>2 Samuel</h1>
+<p><strong>Author:</strong> Unknown</p>
+<p><strong>Date of Writing:</strong> around 930 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (2 Samuel 7:16):</strong> Your house and your kingdom shall be made sure forever before me.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 24</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 24.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 24;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/11-1-kings.html
+++ b/11-1-kings.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>1 Kings</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>1 Kings</h1>
+<p><strong>Author:</strong> Unknown</p>
+<p><strong>Date of Writing:</strong> after 586 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (1 Kings 18:21):</strong> How long will you go limping between two different opinions?</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 22</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 22.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 22;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/12-2-kings.html
+++ b/12-2-kings.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>2 Kings</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>2 Kings</h1>
+<p><strong>Author:</strong> Unknown</p>
+<p><strong>Date of Writing:</strong> after 586 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (2 Kings 18:5):</strong> He trusted in the LORD, the God of Israel.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 25</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 25.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 25;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/13-1-chronicles.html
+++ b/13-1-chronicles.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>1 Chronicles</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>1 Chronicles</h1>
+<p><strong>Author:</strong> Ezra (tradition)</p>
+<p><strong>Date of Writing:</strong> after 538 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (1 Chronicles 16:34):</strong> Give thanks to the LORD, for he is good; for his steadfast love endures forever.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 29</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 29.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 29;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/14-2-chronicles.html
+++ b/14-2-chronicles.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>2 Chronicles</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>2 Chronicles</h1>
+<p><strong>Author:</strong> Ezra (tradition)</p>
+<p><strong>Date of Writing:</strong> after 538 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (2 Chronicles 7:14):</strong> If my people who are called by my name humble themselves...</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 36</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 36.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 36;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/15-ezra.html
+++ b/15-ezra.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Ezra</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Ezra</h1>
+<p><strong>Author:</strong> Ezra</p>
+<p><strong>Date of Writing:</strong> around 450 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Nehemiah 8:10):</strong> The joy of the LORD is your strength.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 10</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 10.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 10;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/16-nehemiah.html
+++ b/16-nehemiah.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Nehemiah</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Nehemiah</h1>
+<p><strong>Author:</strong> Nehemiah</p>
+<p><strong>Date of Writing:</strong> around 430 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Nehemiah 13:31):</strong> Remember me, O my God, for good.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 13</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 13.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 13;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/17-esther.html
+++ b/17-esther.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Esther</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Esther</h1>
+<p><strong>Author:</strong> Unknown</p>
+<p><strong>Date of Writing:</strong> around 400 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Esther 4:14):</strong> And who knows whether you have not come to the kingdom for such a time as this?</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 10</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 10.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 10;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/18-job.html
+++ b/18-job.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Job</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Job</h1>
+<p><strong>Author:</strong> Unknown</p>
+<p><strong>Date of Writing:</strong> unknown</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Job 19:25):</strong> I know that my Redeemer lives, and at the last he will stand upon the earth.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 42</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 42.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 42;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/19-psalms.html
+++ b/19-psalms.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Psalms</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Psalms</h1>
+<p><strong>Author:</strong> Various</p>
+<p><strong>Date of Writing:</strong> 1000-400 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Psalm 23:1):</strong> The LORD is my shepherd; I shall not want.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 150</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 150.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 150;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/2-exodus.html
+++ b/2-exodus.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Exodus</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Exodus</h1>
+<p><strong>Author:</strong> Traditionally Moses</p>
+<p><strong>Date of Writing:</strong> around 1440-1400 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Exodus 14:14):</strong> The LORD will fight for you, and you have only to be silent.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 40</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 40.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 40;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/20-proverbs.html
+++ b/20-proverbs.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Proverbs</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Proverbs</h1>
+<p><strong>Author:</strong> Solomon and others</p>
+<p><strong>Date of Writing:</strong> around 900-700 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Proverbs 3:5):</strong> Trust in the LORD with all your heart, and do not lean on your own understanding.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 31</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 31.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 31;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/21-ecclesiastes.html
+++ b/21-ecclesiastes.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Ecclesiastes</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Ecclesiastes</h1>
+<p><strong>Author:</strong> Solomon (tradition)</p>
+<p><strong>Date of Writing:</strong> around 935 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Ecclesiastes 12:13):</strong> Fear God and keep his commandments, for this is the whole duty of man.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 12</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 12.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 12;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/22-song-of-solomon.html
+++ b/22-song-of-solomon.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Song of Solomon</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Song of Solomon</h1>
+<p><strong>Author:</strong> Solomon (tradition)</p>
+<p><strong>Date of Writing:</strong> around 950 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Song of Solomon 8:7):</strong> Many waters cannot quench love, neither can floods drown it.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 8</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 8.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 8;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/23-isaiah.html
+++ b/23-isaiah.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Isaiah</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Isaiah</h1>
+<p><strong>Author:</strong> Isaiah</p>
+<p><strong>Date of Writing:</strong> around 700 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Isaiah 53:5):</strong> But he was pierced for our transgressions...</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 66</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 66.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 66;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/24-jeremiah.html
+++ b/24-jeremiah.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Jeremiah</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Jeremiah</h1>
+<p><strong>Author:</strong> Jeremiah</p>
+<p><strong>Date of Writing:</strong> 626-580 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Jeremiah 29:11):</strong> For I know the plans I have for you, declares the LORD...</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 52</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 52.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 52;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/25-lamentations.html
+++ b/25-lamentations.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Lamentations</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Lamentations</h1>
+<p><strong>Author:</strong> Jeremiah</p>
+<p><strong>Date of Writing:</strong> 586 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Lamentations 3:22):</strong> The steadfast love of the LORD never ceases; his mercies never come to an end.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 5</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 5.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 5;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/26-ezekiel.html
+++ b/26-ezekiel.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Ezekiel</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Ezekiel</h1>
+<p><strong>Author:</strong> Ezekiel</p>
+<p><strong>Date of Writing:</strong> 593-571 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Ezekiel 36:26):</strong> And I will give you a new heart, and a new spirit I will put within you.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 48</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 48.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 48;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/27-daniel.html
+++ b/27-daniel.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Daniel</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Daniel</h1>
+<p><strong>Author:</strong> Daniel</p>
+<p><strong>Date of Writing:</strong> 530 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Daniel 7:13):</strong> And behold, with the clouds of heaven there came one like a son of man.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 12</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 12.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 12;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/28-hosea.html
+++ b/28-hosea.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Hosea</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Hosea</h1>
+<p><strong>Author:</strong> Hosea</p>
+<p><strong>Date of Writing:</strong> about 750 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Hosea 6:6):</strong> I desire steadfast love and not sacrifice, the knowledge of God rather than burnt offerings.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 14</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 14.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 14;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/29-joel.html
+++ b/29-joel.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Joel</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Joel</h1>
+<p><strong>Author:</strong> Joel</p>
+<p><strong>Date of Writing:</strong> about 800 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Joel 2:28):</strong> I will pour out my Spirit on all flesh.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 3</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 3;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/3-leviticus.html
+++ b/3-leviticus.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Leviticus</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Leviticus</h1>
+<p><strong>Author:</strong> Traditionally Moses</p>
+<p><strong>Date of Writing:</strong> around 1440-1400 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Leviticus 19:2):</strong> You shall be holy, for I the LORD your God am holy.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 27</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 27.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 27;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/30-amos.html
+++ b/30-amos.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Amos</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Amos</h1>
+<p><strong>Author:</strong> Amos</p>
+<p><strong>Date of Writing:</strong> about 760 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Amos 5:24):</strong> Let justice roll down like waters, and righteousness like an ever-flowing stream.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 9</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 9.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 9;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/31-obadiah.html
+++ b/31-obadiah.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Obadiah</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Obadiah</h1>
+<p><strong>Author:</strong> Obadiah</p>
+<p><strong>Date of Writing:</strong> about 586 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Obadiah 1:21):</strong> The kingdom shall be the LORD's.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 1</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 1.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 1;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/32-jonah.html
+++ b/32-jonah.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Jonah</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Jonah</h1>
+<p><strong>Author:</strong> Jonah</p>
+<p><strong>Date of Writing:</strong> about 760 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Jonah 2:9):</strong> Salvation belongs to the LORD!</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 4</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 4;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/33-micah.html
+++ b/33-micah.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Micah</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Micah</h1>
+<p><strong>Author:</strong> Micah</p>
+<p><strong>Date of Writing:</strong> about 700 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Micah 6:8):</strong> He has told you, O man, what is good and what does the LORD require of you but to do justice, and to love kindness, and to walk humbly with your God?</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 7</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 7.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 7;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/34-nahum.html
+++ b/34-nahum.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Nahum</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Nahum</h1>
+<p><strong>Author:</strong> Nahum</p>
+<p><strong>Date of Writing:</strong> about 650 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Nahum 1:7):</strong> The LORD is good, a stronghold in the day of trouble.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 3</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 3;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/35-habakkuk.html
+++ b/35-habakkuk.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Habakkuk</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Habakkuk</h1>
+<p><strong>Author:</strong> Habakkuk</p>
+<p><strong>Date of Writing:</strong> about 600 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Habakkuk 2:4):</strong> The righteous shall live by his faith.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 3</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 3;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/36-zephaniah.html
+++ b/36-zephaniah.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Zephaniah</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Zephaniah</h1>
+<p><strong>Author:</strong> Zephaniah</p>
+<p><strong>Date of Writing:</strong> about 640 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Zephaniah 3:17):</strong> The LORD your God is in your midst, a mighty one who will save.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 3</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 3;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/37-haggai.html
+++ b/37-haggai.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Haggai</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Haggai</h1>
+<p><strong>Author:</strong> Haggai</p>
+<p><strong>Date of Writing:</strong> 520 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Haggai 2:4):</strong> Yet now be strong... declares the LORD.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 2</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 2.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 2;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/38-zechariah.html
+++ b/38-zechariah.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Zechariah</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Zechariah</h1>
+<p><strong>Author:</strong> Zechariah</p>
+<p><strong>Date of Writing:</strong> 520-480 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Zechariah 4:6):</strong> Not by might, nor by power, but by my Spirit, says the LORD of hosts.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 14</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 14.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 14;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/39-malachi.html
+++ b/39-malachi.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Malachi</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Malachi</h1>
+<p><strong>Author:</strong> Malachi</p>
+<p><strong>Date of Writing:</strong> around 430 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Malachi 3:10):</strong> Bring the full tithe into the storehouse, that there may be food in my house.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 4</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 4;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/4-numbers.html
+++ b/4-numbers.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Numbers</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Numbers</h1>
+<p><strong>Author:</strong> Traditionally Moses</p>
+<p><strong>Date of Writing:</strong> around 1440-1400 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Numbers 6:24-25):</strong> The LORD bless you and keep you; the LORD make his face to shine upon you and be gracious to you.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 36</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 36.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 36;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/40-matthew.html
+++ b/40-matthew.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Matthew</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Matthew</h1>
+<p><strong>Author:</strong> Matthew</p>
+<p><strong>Date of Writing:</strong> A.D. 50-60</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Matthew 28:19):</strong> Go therefore and make disciples of all nations...</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 28</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 28.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 28;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/41-mark.html
+++ b/41-mark.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Mark</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Mark</h1>
+<p><strong>Author:</strong> Mark</p>
+<p><strong>Date of Writing:</strong> A.D. 50-60</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Mark 10:45):</strong> For even the Son of Man came not to be served but to serve, and to give his life as a ransom for many.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 16</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 16.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 16;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/42-luke.html
+++ b/42-luke.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Luke</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Luke</h1>
+<p><strong>Author:</strong> Luke</p>
+<p><strong>Date of Writing:</strong> A.D. 60</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Luke 19:10):</strong> For the Son of Man came to seek and to save the lost.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 24</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 24.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 24;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/43-john.html
+++ b/43-john.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>John</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>John</h1>
+<p><strong>Author:</strong> John</p>
+<p><strong>Date of Writing:</strong> A.D. 80-90</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (John 1:1):</strong> In the beginning was the Word, and the Word was with God, and the Word was God.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 21</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 21.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 21;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/44-acts.html
+++ b/44-acts.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Acts</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Acts</h1>
+<p><strong>Author:</strong> Luke</p>
+<p><strong>Date of Writing:</strong> A.D. 62</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Acts 1:8):</strong> And you will be my witnesses...</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 28</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 28.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 28;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/45-romans.html
+++ b/45-romans.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Romans</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Romans</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 57</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Romans 1:16):</strong> For I am not ashamed of the gospel...</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 16</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 16.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 16;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/46-1-corinthians.html
+++ b/46-1-corinthians.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>1 Corinthians</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>1 Corinthians</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 55</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (1 Corinthians 13:4):</strong> Love is patient and kind; love does not envy or boast...</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 16</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 16.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 16;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/47-2-corinthians.html
+++ b/47-2-corinthians.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>2 Corinthians</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>2 Corinthians</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 55-56</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (2 Corinthians 12:9):</strong> My grace is sufficient for you, for my power is made perfect in weakness.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 13</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 13.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 13;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/48-galatians.html
+++ b/48-galatians.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Galatians</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Galatians</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 49</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Galatians 5:1):</strong> For freedom Christ has set us free...</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 6</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 6.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 6;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/49-ephesians.html
+++ b/49-ephesians.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Ephesians</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Ephesians</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 60</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Ephesians 2:8):</strong> For by grace you have been saved through faith.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 6</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 6.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 6;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/5-deuteronomy.html
+++ b/5-deuteronomy.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Deuteronomy</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Deuteronomy</h1>
+<p><strong>Author:</strong> Traditionally Moses</p>
+<p><strong>Date of Writing:</strong> around 1400 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Deuteronomy 6:4):</strong> Hear, O Israel: The LORD our God, the LORD is one.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 34</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 34.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 34;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/50-philippians.html
+++ b/50-philippians.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Philippians</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Philippians</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 60</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Philippians 4:4):</strong> Rejoice in the Lord always; again I will say, Rejoice.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 4</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 4;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/51-colossians.html
+++ b/51-colossians.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Colossians</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Colossians</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 60</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Colossians 1:15):</strong> He is the image of the invisible God, the firstborn of all creation.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 4</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 4;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/52-1-thessalonians.html
+++ b/52-1-thessalonians.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>1 Thessalonians</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>1 Thessalonians</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 51</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (1 Thessalonians 4:3):</strong> For this is the will of God, your sanctification.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 5</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 5.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 5;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/53-2-thessalonians.html
+++ b/53-2-thessalonians.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>2 Thessalonians</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>2 Thessalonians</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 51-52</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (2 Thessalonians 3:3):</strong> But the Lord is faithful. He will establish you and guard you against the evil one.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 3</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 3;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/54-1-timothy.html
+++ b/54-1-timothy.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>1 Timothy</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>1 Timothy</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 62-64</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (1 Timothy 6:12):</strong> Fight the good fight of the faith.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 6</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 6.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 6;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/55-2-timothy.html
+++ b/55-2-timothy.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>2 Timothy</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>2 Timothy</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 64-67</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (2 Timothy 4:7):</strong> I have fought the good fight, I have finished the race, I have kept the faith.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 4</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 4;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/56-titus.html
+++ b/56-titus.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Titus</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Titus</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 63</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Titus 3:5):</strong> He saved us... by the washing of regeneration and renewal of the Holy Spirit.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 3</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 3;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/57-philemon.html
+++ b/57-philemon.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Philemon</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Philemon</h1>
+<p><strong>Author:</strong> Paul</p>
+<p><strong>Date of Writing:</strong> A.D. 60</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Philemon 1:12):</strong> I am sending him back to you, sending my very heart.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 1</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 1.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 1;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/58-hebrews.html
+++ b/58-hebrews.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Hebrews</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Hebrews</h1>
+<p><strong>Author:</strong> Unknown</p>
+<p><strong>Date of Writing:</strong> A.D. 60-70</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Hebrews 4:16):</strong> Let us then with confidence draw near to the throne of grace.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 13</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 13.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 13;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/59-james.html
+++ b/59-james.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>James</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>James</h1>
+<p><strong>Author:</strong> James</p>
+<p><strong>Date of Writing:</strong> A.D. 40-50</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (James 1:22):</strong> But be doers of the word, and not hearers only.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 5</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 5.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 5;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/6-joshua.html
+++ b/6-joshua.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Joshua</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Joshua</h1>
+<p><strong>Author:</strong> Joshua</p>
+<p><strong>Date of Writing:</strong> about 1400-1370 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Joshua 1:9):</strong> Be strong and courageous. Do not be frightened, and do not be dismayed, for the LORD your God is with you wherever you go.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 24</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 24.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 24;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/60-1-peter.html
+++ b/60-1-peter.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>1 Peter</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>1 Peter</h1>
+<p><strong>Author:</strong> Peter</p>
+<p><strong>Date of Writing:</strong> A.D. 60</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (1 Peter 5:6):</strong> Humble yourselves... under the mighty hand of God.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 5</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 5.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 5;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/61-2-peter.html
+++ b/61-2-peter.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>2 Peter</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>2 Peter</h1>
+<p><strong>Author:</strong> Peter</p>
+<p><strong>Date of Writing:</strong> A.D. 60-68</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (2 Peter 3:9):</strong> The Lord is not slow to fulfill his promise... but is patient toward you.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 3</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 3;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/62-1-john.html
+++ b/62-1-john.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>1 John</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>1 John</h1>
+<p><strong>Author:</strong> John</p>
+<p><strong>Date of Writing:</strong> A.D. 85-95</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (1 John 1:5):</strong> God is light, and in him is no darkness at all.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 5</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 5.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 5;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/63-2-john.html
+++ b/63-2-john.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>2 John</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>2 John</h1>
+<p><strong>Author:</strong> John</p>
+<p><strong>Date of Writing:</strong> A.D. 85-95</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (2 John 1:6):</strong> This is love, that we walk according to his commandments.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 1</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 1.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 1;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/64-3-john.html
+++ b/64-3-john.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>3 John</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>3 John</h1>
+<p><strong>Author:</strong> John</p>
+<p><strong>Date of Writing:</strong> A.D. 85-95</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (3 John 1:4):</strong> I have no greater joy than to hear that my children are walking in the truth.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 1</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 1.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 1;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/65-jude.html
+++ b/65-jude.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Jude</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Jude</h1>
+<p><strong>Author:</strong> Jude</p>
+<p><strong>Date of Writing:</strong> A.D. 65-80</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Jude 1:3):</strong> Contend for the faith that was once for all delivered to the saints.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 1</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 1.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 1;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/66-revelation.html
+++ b/66-revelation.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Revelation</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Revelation</h1>
+<p><strong>Author:</strong> John</p>
+<p><strong>Date of Writing:</strong> A.D. 95</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Revelation 5:12):</strong> Worthy is the Lamb who was slain, to receive power and wealth and wisdom and might and honor and glory and blessing!</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 22</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 22.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 22;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/7-judges.html
+++ b/7-judges.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Judges</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Judges</h1>
+<p><strong>Author:</strong> Unknown</p>
+<p><strong>Date of Writing:</strong> around 1050 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Judges 21:25):</strong> In those days there was no king in Israel. Everyone did what was right in his own eyes.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 21</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 21.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 21;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/8-ruth.html
+++ b/8-ruth.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Ruth</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Ruth</h1>
+<p><strong>Author:</strong> Unknown</p>
+<p><strong>Date of Writing:</strong> around 1000 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (Ruth 1:16):</strong> Where you go I will go, and where you lodge I will lodge.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 4</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 4;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/9-1-samuel.html
+++ b/9-1-samuel.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>1 Samuel</title>
+<style>
+  body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
+  h1 { color: #2c3e50; }
+  button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
+  .back { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>1 Samuel</h1>
+<p><strong>Author:</strong> Samuel and others</p>
+<p><strong>Date of Writing:</strong> around 930 B.C.</p>
+<p>This book holds a key place in the biblical story.</p>
+<p>It reveals God's faithfulness and points to Christ.</p>
+<p><strong>Famous Verse (1 Samuel 16:7):</strong> Man looks on the outward appearance, but the LORD looks on the heart.</p>
+<p>Throughout church history, believers have drawn encouragement from this book.</p>
+<h2>Random Chapter Generator</h2>
+<p>Chapters: 31</p>
+<button onclick='roll()'>Roll Chapter</button>
+<p id='result'></p>
+<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 31.</p>
+<p class='back'><a href='index.html'>Back to Index</a></p>
+<script>
+function roll() {
+  var max = 31;
+  var num = Math.floor(Math.random() * max) + 1;
+  document.getElementById('result').innerText = 'Chapter ' + num;
+}
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -102,284 +102,243 @@
       <thead>
         <tr>
           <th>Number</th>
-          <th>Old Testament</th>
-          <th></th>
+          <th>Book</th>
           <th>Number</th>
-          <th>New Testament</th>
-          <th></th>
+          <th>Book</th>
           <th>Chapter Help</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td>10</td>
-          <td>2 Samuel</td>
-          <td></td>
+          <td>1</td>
+          <td><a href="1-genesis.html">Genesis</a></td>
+          <td>34</td>
+          <td><a href="34-nahum.html">Nahum</a></td>
+          <td class="chapter-help"><a href="tables/gospels.html">Chapter Help</a></td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td><a href="2-exodus.html">Exodus</a></td>
+          <td>35</td>
+          <td><a href="35-habakkuk.html">Habakkuk</a></td>
+          <td class="chapter-help"><a href="tables/wisdom-lit.html">Chapter Help</a></td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td><a href="3-leviticus.html">Leviticus</a></td>
+          <td>36</td>
+          <td><a href="36-zephaniah.html">Zephaniah</a></td>
+          <td class="chapter-help"><a href="tables/psalms.html">Chapter Help</a></td>
+        </tr>
+        <tr>
+          <td>4</td>
+          <td><a href="4-numbers.html">Numbers</a></td>
+          <td>37</td>
+          <td><a href="37-haggai.html">Haggai</a></td>
+          <td class="chapter-help"><a href="tables/pauline-epistles2.html">Chapter Help</a></td>
+        </tr>
+        <tr>
+          <td>5</td>
+          <td><a href="5-deuteronomy.html">Deuteronomy</a></td>
+          <td>38</td>
+          <td><a href="38-zechariah.html">Zechariah</a></td>
+          <td class="chapter-help"><a href="tables/isaiah.html">Chapter Help</a></td>
+        </tr>
+        <tr>
+          <td>6</td>
+          <td><a href="6-joshua.html">Joshua</a></td>
+          <td>39</td>
+          <td><a href="39-malachi.html">Malachi</a></td>
+          <td class="chapter-help"><a href="tables/jeremiah.html">Chapter Help</a></td>
+        </tr>
+        <tr>
+          <td>7</td>
+          <td><a href="7-judges.html">Judges</a></td>
           <td>40</td>
-          <td>Matthew</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/gospels.html">Gospels</a></td>
+          <td><a href="40-matthew.html">Matthew</a></td>
+          <td class="chapter-help"><a href="tables/grief-lit.html">Chapter Help</a></td>
+        </tr>
+        <tr>
+          <td>8</td>
+          <td><a href="8-ruth.html">Ruth</a></td>
+          <td>41</td>
+          <td><a href="41-mark.html">Mark</a></td>
+          <td class="chapter-help"><a href="tables/ezekiel.html">Chapter Help</a></td>
+        </tr>
+        <tr>
+          <td>9</td>
+          <td><a href="9-1-samuel.html">1 Samuel</a></td>
+          <td>42</td>
+          <td><a href="42-luke.html">Luke</a></td>
+          <td class="chapter-help"><a href="tables/daniel.html">Chapter Help</a></td>
+        </tr>
+        <tr>
+          <td>10</td>
+          <td><a href="10-2-samuel.html">2 Samuel</a></td>
+          <td>43</td>
+          <td><a href="43-john.html">John</a></td>
+          <td class="chapter-help"><a href="tables/minor-prophets.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>11</td>
-          <td>1 Kings</td>
-          <td></td>
-          <td>42</td>
-          <td>Luke</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/wisdom-lit.html">Wisdom Literature</a></td>
+          <td><a href="11-1-kings.html">1 Kings</a></td>
+          <td>44</td>
+          <td><a href="44-acts.html">Acts</a></td>
+          <td class="chapter-help"><a href="tables/prophets.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>12</td>
-          <td>2 Kings</td>
-          <td></td>
-          <td>43</td>
-          <td>John</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/psalms.html">Psalms</a></td>
+          <td><a href="12-2-kings.html">2 Kings</a></td>
+          <td>45</td>
+          <td><a href="45-romans.html">Romans</a></td>
+          <td class="chapter-help"><a href="tables/psalm119.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>13</td>
-          <td>1 Chronicles</td>
-          <td></td>
-          <td>44</td>
-          <td>Acts</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/pauline-epistles2.html">Pauline Epistles 2</a></td>
+          <td><a href="13-1-chronicles.html">1 Chronicles</a></td>
+          <td>46</td>
+          <td><a href="46-1-corinthians.html">1 Corinthians</a></td>
+          <td class="chapter-help"><a href="tables/gospels.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>14</td>
-          <td>2 Chronicles</td>
-          <td></td>
-          <td>45</td>
-          <td>Romans</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/isaiah.html">Isaiah</a></td>
+          <td><a href="14-2-chronicles.html">2 Chronicles</a></td>
+          <td>47</td>
+          <td><a href="47-2-corinthians.html">2 Corinthians</a></td>
+          <td class="chapter-help"><a href="tables/wisdom-lit.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>15</td>
-          <td>Ezra</td>
-          <td></td>
-          <td>46</td>
-          <td>1 Corinthians</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/jeremiah.html">Jeremiah</a></td>
+          <td><a href="15-ezra.html">Ezra</a></td>
+          <td>48</td>
+          <td><a href="48-galatians.html">Galatians</a></td>
+          <td class="chapter-help"><a href="tables/psalms.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>16</td>
-          <td>Nehemiah</td>
-          <td></td>
-          <td>47</td>
-          <td>2 Corinthians</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/grief-lit.html">Grief Literature</a></td>
+          <td><a href="16-nehemiah.html">Nehemiah</a></td>
+          <td>49</td>
+          <td><a href="49-ephesians.html">Ephesians</a></td>
+          <td class="chapter-help"><a href="tables/pauline-epistles2.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>17</td>
-          <td>Esther</td>
-          <td></td>
-          <td>48</td>
-          <td>Galatians</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/ezekiel.html">Ezekiel</a></td>
+          <td><a href="17-esther.html">Esther</a></td>
+          <td>50</td>
+          <td><a href="50-philippians.html">Philippians</a></td>
+          <td class="chapter-help"><a href="tables/isaiah.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>18</td>
-          <td>Job</td>
-          <td></td>
-          <td>49</td>
-          <td>Ephesians</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/daniel.html">Daniel</a></td>
+          <td><a href="18-job.html">Job</a></td>
+          <td>51</td>
+          <td><a href="51-colossians.html">Colossians</a></td>
+          <td class="chapter-help"><a href="tables/jeremiah.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>19</td>
-          <td>Psalms</td>
-          <td></td>
-          <td>50</td>
-          <td>Philippians</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/minor-prophets.html">Minor Prophets</a></td>
+          <td><a href="19-psalms.html">Psalms</a></td>
+          <td>52</td>
+          <td><a href="52-1-thessalonians.html">1 Thessalonians</a></td>
+          <td class="chapter-help"><a href="tables/grief-lit.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>20</td>
-          <td>Proverbs</td>
-          <td></td>
-          <td>51</td>
-          <td>Colossians</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/prophets.html">Prophets</a></td>
+          <td><a href="20-proverbs.html">Proverbs</a></td>
+          <td>53</td>
+          <td><a href="53-2-thessalonians.html">2 Thessalonians</a></td>
+          <td class="chapter-help"><a href="tables/ezekiel.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>21</td>
-          <td>Ecclesiastes</td>
-          <td></td>
-          <td>52</td>
-          <td>1 Thessalonians</td>
-          <td></td>
-          <td class="chapter-help"><a href="tables/psalm119.html">Psalm 119</a></td>
+          <td><a href="21-ecclesiastes.html">Ecclesiastes</a></td>
+          <td>54</td>
+          <td><a href="54-1-timothy.html">1 Timothy</a></td>
+          <td class="chapter-help"><a href="tables/daniel.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>22</td>
-          <td>Song of Solomon</td>
-          <td></td>
-          <td>53</td>
-          <td>2 Thessalonians</td>
-          <td></td>
-          <td></td>
+          <td><a href="22-song-of-solomon.html">Song of Solomon</a></td>
+          <td>55</td>
+          <td><a href="55-2-timothy.html">2 Timothy</a></td>
+          <td class="chapter-help"><a href="tables/minor-prophets.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>23</td>
-          <td>Isaiah</td>
-          <td></td>
-          <td>54</td>
-          <td>1 Timothy</td>
-          <td></td>
-          <td></td>
+          <td><a href="23-isaiah.html">Isaiah</a></td>
+          <td>56</td>
+          <td><a href="56-titus.html">Titus</a></td>
+          <td class="chapter-help"><a href="tables/prophets.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>24</td>
-          <td>Jeremiah</td>
-          <td></td>
-          <td>55</td>
-          <td>2 Timothy</td>
-          <td></td>
-          <td></td>
+          <td><a href="24-jeremiah.html">Jeremiah</a></td>
+          <td>57</td>
+          <td><a href="57-philemon.html">Philemon</a></td>
+          <td class="chapter-help"><a href="tables/psalm119.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>25</td>
-          <td>Lamentations</td>
-          <td></td>
-          <td>56</td>
-          <td>Titus</td>
-          <td></td>
-          <td></td>
+          <td><a href="25-lamentations.html">Lamentations</a></td>
+          <td>58</td>
+          <td><a href="58-hebrews.html">Hebrews</a></td>
+          <td class="chapter-help"><a href="tables/gospels.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>26</td>
-          <td>Ezekiel</td>
-          <td></td>
-          <td>57</td>
-          <td>Philemon</td>
-          <td></td>
-          <td></td>
+          <td><a href="26-ezekiel.html">Ezekiel</a></td>
+          <td>59</td>
+          <td><a href="59-james.html">James</a></td>
+          <td class="chapter-help"><a href="tables/wisdom-lit.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>27</td>
-          <td>Daniel</td>
-          <td></td>
-          <td>58</td>
-          <td>Hebrews</td>
-          <td></td>
-          <td></td>
+          <td><a href="27-daniel.html">Daniel</a></td>
+          <td>60</td>
+          <td><a href="60-1-peter.html">1 Peter</a></td>
+          <td class="chapter-help"><a href="tables/psalms.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>28</td>
-          <td>Hosea</td>
-          <td></td>
-          <td>59</td>
-          <td>James</td>
-          <td></td>
-          <td></td>
+          <td><a href="28-hosea.html">Hosea</a></td>
+          <td>61</td>
+          <td><a href="61-2-peter.html">2 Peter</a></td>
+          <td class="chapter-help"><a href="tables/pauline-epistles2.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>29</td>
-          <td>Joel</td>
-          <td></td>
-          <td>60</td>
-          <td>1 Peter</td>
-          <td></td>
-          <td></td>
+          <td><a href="29-joel.html">Joel</a></td>
+          <td>62</td>
+          <td><a href="62-1-john.html">1 John</a></td>
+          <td class="chapter-help"><a href="tables/isaiah.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>30</td>
-          <td>Amos</td>
-          <td></td>
-          <td>61</td>
-          <td>2 Peter</td>
-          <td></td>
-          <td></td>
+          <td><a href="30-amos.html">Amos</a></td>
+          <td>63</td>
+          <td><a href="63-2-john.html">2 John</a></td>
+          <td class="chapter-help"><a href="tables/jeremiah.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>31</td>
-          <td>Obadiah</td>
-          <td></td>
-          <td>62</td>
-          <td>1 John</td>
-          <td></td>
-          <td></td>
+          <td><a href="31-obadiah.html">Obadiah</a></td>
+          <td>64</td>
+          <td><a href="64-3-john.html">3 John</a></td>
+          <td class="chapter-help"><a href="tables/grief-lit.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>32</td>
-          <td>Jonah</td>
-          <td></td>
-          <td>63</td>
-          <td>2 John</td>
-          <td></td>
-          <td></td>
+          <td><a href="32-jonah.html">Jonah</a></td>
+          <td>65</td>
+          <td><a href="65-jude.html">Jude</a></td>
+          <td class="chapter-help"><a href="tables/ezekiel.html">Chapter Help</a></td>
         </tr>
         <tr>
           <td>33</td>
-          <td>Micah</td>
-          <td></td>
-          <td>64</td>
-          <td>3 John</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>34</td>
-          <td>Nahum</td>
-          <td></td>
-          <td>65</td>
-          <td>Jude</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>35</td>
-          <td>Habakkuk</td>
-          <td></td>
+          <td><a href="33-micah.html">Micah</a></td>
           <td>66</td>
-          <td>Revelation</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>36</td>
-          <td>Zephaniah</td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>37</td>
-          <td>Haggai</td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>38</td>
-          <td>Zechariah</td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>39</td>
-          <td>Malachi</td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
+          <td><a href="66-revelation.html">Revelation</a></td>
+          <td class="chapter-help"><a href="tables/daniel.html">Chapter Help</a></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- simplify the book table to three columns
- include all 66 books with links to each HTML page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687c9b6461808320b12d3e9ef3954555