### PR TITLE
Add offline dice instructions and chapter links to Bible book pages

### DIFF
--- a/1-genesis.html
+++ b/1-genesis.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Genesis</h1>
+<body><h1>Genesis</h1>
 <p><strong>Author:</strong> Traditionally Moses</p>
 <p><strong>Date of Writing:</strong> around 1440-1400 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,75 @@
 <p>Chapters: 50</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 50.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 50</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 50 chapters, so valid results are 1-50.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%201&version=NASB1995" target="_blank">Chapter 1 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%202&version=NASB1995" target="_blank">Chapter 2 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%203&version=NASB1995" target="_blank">Chapter 3 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%204&version=NASB1995" target="_blank">Chapter 4 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%205&version=NASB1995" target="_blank">Chapter 5 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%206&version=NASB1995" target="_blank">Chapter 6 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%207&version=NASB1995" target="_blank">Chapter 7 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%208&version=NASB1995" target="_blank">Chapter 8 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%209&version=NASB1995" target="_blank">Chapter 9 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2010&version=NASB1995" target="_blank">Chapter 10 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2011&version=NASB1995" target="_blank">Chapter 11 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2012&version=NASB1995" target="_blank">Chapter 12 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2013&version=NASB1995" target="_blank">Chapter 13 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2014&version=NASB1995" target="_blank">Chapter 14 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2015&version=NASB1995" target="_blank">Chapter 15 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2016&version=NASB1995" target="_blank">Chapter 16 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2017&version=NASB1995" target="_blank">Chapter 17 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2018&version=NASB1995" target="_blank">Chapter 18 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2019&version=NASB1995" target="_blank">Chapter 19 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2020&version=NASB1995" target="_blank">Chapter 20 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2021&version=NASB1995" target="_blank">Chapter 21 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2022&version=NASB1995" target="_blank">Chapter 22 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2023&version=NASB1995" target="_blank">Chapter 23 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2024&version=NASB1995" target="_blank">Chapter 24 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2025&version=NASB1995" target="_blank">Chapter 25 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2026&version=NASB1995" target="_blank">Chapter 26 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2027&version=NASB1995" target="_blank">Chapter 27 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2028&version=NASB1995" target="_blank">Chapter 28 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2029&version=NASB1995" target="_blank">Chapter 29 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2030&version=NASB1995" target="_blank">Chapter 30 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2031&version=NASB1995" target="_blank">Chapter 31 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2032&version=NASB1995" target="_blank">Chapter 32 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2033&version=NASB1995" target="_blank">Chapter 33 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2034&version=NASB1995" target="_blank">Chapter 34 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2035&version=NASB1995" target="_blank">Chapter 35 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2036&version=NASB1995" target="_blank">Chapter 36 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2037&version=NASB1995" target="_blank">Chapter 37 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2038&version=NASB1995" target="_blank">Chapter 38 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2039&version=NASB1995" target="_blank">Chapter 39 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2040&version=NASB1995" target="_blank">Chapter 40 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2041&version=NASB1995" target="_blank">Chapter 41 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2042&version=NASB1995" target="_blank">Chapter 42 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2043&version=NASB1995" target="_blank">Chapter 43 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2044&version=NASB1995" target="_blank">Chapter 44 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2045&version=NASB1995" target="_blank">Chapter 45 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2046&version=NASB1995" target="_blank">Chapter 46 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2047&version=NASB1995" target="_blank">Chapter 47 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2048&version=NASB1995" target="_blank">Chapter 48 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2049&version=NASB1995" target="_blank">Chapter 49 Genesis (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Genesis%2050&version=NASB1995" target="_blank">Chapter 50 Genesis (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 50;

--- a/10-2-samuel.html
+++ b/10-2-samuel.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>2 Samuel</h1>
+<body><h1>2 Samuel</h1>
 <p><strong>Author:</strong> Unknown</p>
 <p><strong>Date of Writing:</strong> around 930 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,49 @@
 <p>Chapters: 24</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 24.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 24</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 24 chapters, so valid results are 1-24.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%201&version=NASB1995" target="_blank">Chapter 1 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%202&version=NASB1995" target="_blank">Chapter 2 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%203&version=NASB1995" target="_blank">Chapter 3 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%204&version=NASB1995" target="_blank">Chapter 4 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%205&version=NASB1995" target="_blank">Chapter 5 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%206&version=NASB1995" target="_blank">Chapter 6 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%207&version=NASB1995" target="_blank">Chapter 7 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%208&version=NASB1995" target="_blank">Chapter 8 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%209&version=NASB1995" target="_blank">Chapter 9 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2010&version=NASB1995" target="_blank">Chapter 10 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2011&version=NASB1995" target="_blank">Chapter 11 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2012&version=NASB1995" target="_blank">Chapter 12 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2013&version=NASB1995" target="_blank">Chapter 13 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2014&version=NASB1995" target="_blank">Chapter 14 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2015&version=NASB1995" target="_blank">Chapter 15 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2016&version=NASB1995" target="_blank">Chapter 16 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2017&version=NASB1995" target="_blank">Chapter 17 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2018&version=NASB1995" target="_blank">Chapter 18 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2019&version=NASB1995" target="_blank">Chapter 19 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2020&version=NASB1995" target="_blank">Chapter 20 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2021&version=NASB1995" target="_blank">Chapter 21 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2022&version=NASB1995" target="_blank">Chapter 22 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2023&version=NASB1995" target="_blank">Chapter 23 2 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Samuel%2024&version=NASB1995" target="_blank">Chapter 24 2 Samuel (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 24;

--- a/11-1-kings.html
+++ b/11-1-kings.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>1 Kings</h1>
+<body><h1>1 Kings</h1>
 <p><strong>Author:</strong> Unknown</p>
 <p><strong>Date of Writing:</strong> after 586 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,47 @@
 <p>Chapters: 22</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 22.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 22</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 22 chapters, so valid results are 1-22.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%201&version=NASB1995" target="_blank">Chapter 1 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%202&version=NASB1995" target="_blank">Chapter 2 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%203&version=NASB1995" target="_blank">Chapter 3 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%204&version=NASB1995" target="_blank">Chapter 4 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%205&version=NASB1995" target="_blank">Chapter 5 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%206&version=NASB1995" target="_blank">Chapter 6 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%207&version=NASB1995" target="_blank">Chapter 7 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%208&version=NASB1995" target="_blank">Chapter 8 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%209&version=NASB1995" target="_blank">Chapter 9 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2010&version=NASB1995" target="_blank">Chapter 10 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2011&version=NASB1995" target="_blank">Chapter 11 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2012&version=NASB1995" target="_blank">Chapter 12 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2013&version=NASB1995" target="_blank">Chapter 13 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2014&version=NASB1995" target="_blank">Chapter 14 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2015&version=NASB1995" target="_blank">Chapter 15 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2016&version=NASB1995" target="_blank">Chapter 16 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2017&version=NASB1995" target="_blank">Chapter 17 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2018&version=NASB1995" target="_blank">Chapter 18 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2019&version=NASB1995" target="_blank">Chapter 19 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2020&version=NASB1995" target="_blank">Chapter 20 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2021&version=NASB1995" target="_blank">Chapter 21 1 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Kings%2022&version=NASB1995" target="_blank">Chapter 22 1 Kings (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 22;

--- a/12-2-kings.html
+++ b/12-2-kings.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>2 Kings</h1>
+<body><h1>2 Kings</h1>
 <p><strong>Author:</strong> Unknown</p>
 <p><strong>Date of Writing:</strong> after 586 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,50 @@
 <p>Chapters: 25</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 25.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 25</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 25 chapters, so valid results are 1-25.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%201&version=NASB1995" target="_blank">Chapter 1 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%202&version=NASB1995" target="_blank">Chapter 2 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%203&version=NASB1995" target="_blank">Chapter 3 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%204&version=NASB1995" target="_blank">Chapter 4 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%205&version=NASB1995" target="_blank">Chapter 5 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%206&version=NASB1995" target="_blank">Chapter 6 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%207&version=NASB1995" target="_blank">Chapter 7 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%208&version=NASB1995" target="_blank">Chapter 8 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%209&version=NASB1995" target="_blank">Chapter 9 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2010&version=NASB1995" target="_blank">Chapter 10 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2011&version=NASB1995" target="_blank">Chapter 11 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2012&version=NASB1995" target="_blank">Chapter 12 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2013&version=NASB1995" target="_blank">Chapter 13 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2014&version=NASB1995" target="_blank">Chapter 14 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2015&version=NASB1995" target="_blank">Chapter 15 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2016&version=NASB1995" target="_blank">Chapter 16 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2017&version=NASB1995" target="_blank">Chapter 17 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2018&version=NASB1995" target="_blank">Chapter 18 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2019&version=NASB1995" target="_blank">Chapter 19 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2020&version=NASB1995" target="_blank">Chapter 20 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2021&version=NASB1995" target="_blank">Chapter 21 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2022&version=NASB1995" target="_blank">Chapter 22 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2023&version=NASB1995" target="_blank">Chapter 23 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2024&version=NASB1995" target="_blank">Chapter 24 2 Kings (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Kings%2025&version=NASB1995" target="_blank">Chapter 25 2 Kings (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 25;

--- a/13-1-chronicles.html
+++ b/13-1-chronicles.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>1 Chronicles</h1>
+<body><h1>1 Chronicles</h1>
 <p><strong>Author:</strong> Ezra (tradition)</p>
 <p><strong>Date of Writing:</strong> after 538 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,54 @@
 <p>Chapters: 29</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 29.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 29</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 29 chapters, so valid results are 1-29.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%201&version=NASB1995" target="_blank">Chapter 1 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%202&version=NASB1995" target="_blank">Chapter 2 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%203&version=NASB1995" target="_blank">Chapter 3 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%204&version=NASB1995" target="_blank">Chapter 4 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%205&version=NASB1995" target="_blank">Chapter 5 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%206&version=NASB1995" target="_blank">Chapter 6 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%207&version=NASB1995" target="_blank">Chapter 7 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%208&version=NASB1995" target="_blank">Chapter 8 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%209&version=NASB1995" target="_blank">Chapter 9 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2010&version=NASB1995" target="_blank">Chapter 10 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2011&version=NASB1995" target="_blank">Chapter 11 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2012&version=NASB1995" target="_blank">Chapter 12 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2013&version=NASB1995" target="_blank">Chapter 13 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2014&version=NASB1995" target="_blank">Chapter 14 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2015&version=NASB1995" target="_blank">Chapter 15 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2016&version=NASB1995" target="_blank">Chapter 16 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2017&version=NASB1995" target="_blank">Chapter 17 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2018&version=NASB1995" target="_blank">Chapter 18 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2019&version=NASB1995" target="_blank">Chapter 19 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2020&version=NASB1995" target="_blank">Chapter 20 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2021&version=NASB1995" target="_blank">Chapter 21 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2022&version=NASB1995" target="_blank">Chapter 22 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2023&version=NASB1995" target="_blank">Chapter 23 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2024&version=NASB1995" target="_blank">Chapter 24 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2025&version=NASB1995" target="_blank">Chapter 25 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2026&version=NASB1995" target="_blank">Chapter 26 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2027&version=NASB1995" target="_blank">Chapter 27 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2028&version=NASB1995" target="_blank">Chapter 28 1 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Chronicles%2029&version=NASB1995" target="_blank">Chapter 29 1 Chronicles (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 29;

--- a/14-2-chronicles.html
+++ b/14-2-chronicles.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>2 Chronicles</h1>
+<body><h1>2 Chronicles</h1>
 <p><strong>Author:</strong> Ezra (tradition)</p>
 <p><strong>Date of Writing:</strong> after 538 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,61 @@
 <p>Chapters: 36</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 36.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 36</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 36 chapters, so valid results are 1-36.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%201&version=NASB1995" target="_blank">Chapter 1 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%202&version=NASB1995" target="_blank">Chapter 2 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%203&version=NASB1995" target="_blank">Chapter 3 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%204&version=NASB1995" target="_blank">Chapter 4 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%205&version=NASB1995" target="_blank">Chapter 5 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%206&version=NASB1995" target="_blank">Chapter 6 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%207&version=NASB1995" target="_blank">Chapter 7 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%208&version=NASB1995" target="_blank">Chapter 8 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%209&version=NASB1995" target="_blank">Chapter 9 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2010&version=NASB1995" target="_blank">Chapter 10 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2011&version=NASB1995" target="_blank">Chapter 11 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2012&version=NASB1995" target="_blank">Chapter 12 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2013&version=NASB1995" target="_blank">Chapter 13 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2014&version=NASB1995" target="_blank">Chapter 14 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2015&version=NASB1995" target="_blank">Chapter 15 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2016&version=NASB1995" target="_blank">Chapter 16 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2017&version=NASB1995" target="_blank">Chapter 17 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2018&version=NASB1995" target="_blank">Chapter 18 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2019&version=NASB1995" target="_blank">Chapter 19 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2020&version=NASB1995" target="_blank">Chapter 20 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2021&version=NASB1995" target="_blank">Chapter 21 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2022&version=NASB1995" target="_blank">Chapter 22 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2023&version=NASB1995" target="_blank">Chapter 23 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2024&version=NASB1995" target="_blank">Chapter 24 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2025&version=NASB1995" target="_blank">Chapter 25 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2026&version=NASB1995" target="_blank">Chapter 26 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2027&version=NASB1995" target="_blank">Chapter 27 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2028&version=NASB1995" target="_blank">Chapter 28 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2029&version=NASB1995" target="_blank">Chapter 29 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2030&version=NASB1995" target="_blank">Chapter 30 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2031&version=NASB1995" target="_blank">Chapter 31 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2032&version=NASB1995" target="_blank">Chapter 32 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2033&version=NASB1995" target="_blank">Chapter 33 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2034&version=NASB1995" target="_blank">Chapter 34 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2035&version=NASB1995" target="_blank">Chapter 35 2 Chronicles (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Chronicles%2036&version=NASB1995" target="_blank">Chapter 36 2 Chronicles (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 36;

--- a/15-ezra.html
+++ b/15-ezra.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Ezra</h1>
+<body><h1>Ezra</h1>
 <p><strong>Author:</strong> Ezra</p>
 <p><strong>Date of Writing:</strong> around 450 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,35 @@
 <p>Chapters: 10</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 10.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 10</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 10 chapters, so valid results are 1-10.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Ezra%201&version=NASB1995" target="_blank">Chapter 1 Ezra (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezra%202&version=NASB1995" target="_blank">Chapter 2 Ezra (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezra%203&version=NASB1995" target="_blank">Chapter 3 Ezra (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezra%204&version=NASB1995" target="_blank">Chapter 4 Ezra (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezra%205&version=NASB1995" target="_blank">Chapter 5 Ezra (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezra%206&version=NASB1995" target="_blank">Chapter 6 Ezra (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezra%207&version=NASB1995" target="_blank">Chapter 7 Ezra (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezra%208&version=NASB1995" target="_blank">Chapter 8 Ezra (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezra%209&version=NASB1995" target="_blank">Chapter 9 Ezra (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezra%2010&version=NASB1995" target="_blank">Chapter 10 Ezra (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 10;

--- a/16-nehemiah.html
+++ b/16-nehemiah.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Nehemiah</h1>
+<body><h1>Nehemiah</h1>
 <p><strong>Author:</strong> Nehemiah</p>
 <p><strong>Date of Writing:</strong> around 430 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,38 @@
 <p>Chapters: 13</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 13.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 13</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 13 chapters, so valid results are 1-13.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%201&version=NASB1995" target="_blank">Chapter 1 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%202&version=NASB1995" target="_blank">Chapter 2 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%203&version=NASB1995" target="_blank">Chapter 3 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%204&version=NASB1995" target="_blank">Chapter 4 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%205&version=NASB1995" target="_blank">Chapter 5 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%206&version=NASB1995" target="_blank">Chapter 6 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%207&version=NASB1995" target="_blank">Chapter 7 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%208&version=NASB1995" target="_blank">Chapter 8 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%209&version=NASB1995" target="_blank">Chapter 9 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%2010&version=NASB1995" target="_blank">Chapter 10 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%2011&version=NASB1995" target="_blank">Chapter 11 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%2012&version=NASB1995" target="_blank">Chapter 12 Nehemiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nehemiah%2013&version=NASB1995" target="_blank">Chapter 13 Nehemiah (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 13;

--- a/17-esther.html
+++ b/17-esther.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Esther</h1>
+<body><h1>Esther</h1>
 <p><strong>Author:</strong> Unknown</p>
 <p><strong>Date of Writing:</strong> around 400 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,35 @@
 <p>Chapters: 10</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 10.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 10</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 10 chapters, so valid results are 1-10.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Esther%201&version=NASB1995" target="_blank">Chapter 1 Esther (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Esther%202&version=NASB1995" target="_blank">Chapter 2 Esther (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Esther%203&version=NASB1995" target="_blank">Chapter 3 Esther (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Esther%204&version=NASB1995" target="_blank">Chapter 4 Esther (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Esther%205&version=NASB1995" target="_blank">Chapter 5 Esther (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Esther%206&version=NASB1995" target="_blank">Chapter 6 Esther (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Esther%207&version=NASB1995" target="_blank">Chapter 7 Esther (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Esther%208&version=NASB1995" target="_blank">Chapter 8 Esther (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Esther%209&version=NASB1995" target="_blank">Chapter 9 Esther (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Esther%2010&version=NASB1995" target="_blank">Chapter 10 Esther (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 10;

--- a/18-job.html
+++ b/18-job.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Job</h1>
+<body><h1>Job</h1>
 <p><strong>Author:</strong> Unknown</p>
 <p><strong>Date of Writing:</strong> unknown</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,67 @@
 <p>Chapters: 42</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 42.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 42</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 42 chapters, so valid results are 1-42.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Job%201&version=NASB1995" target="_blank">Chapter 1 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%202&version=NASB1995" target="_blank">Chapter 2 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%203&version=NASB1995" target="_blank">Chapter 3 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%204&version=NASB1995" target="_blank">Chapter 4 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%205&version=NASB1995" target="_blank">Chapter 5 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%206&version=NASB1995" target="_blank">Chapter 6 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%207&version=NASB1995" target="_blank">Chapter 7 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%208&version=NASB1995" target="_blank">Chapter 8 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%209&version=NASB1995" target="_blank">Chapter 9 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2010&version=NASB1995" target="_blank">Chapter 10 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2011&version=NASB1995" target="_blank">Chapter 11 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2012&version=NASB1995" target="_blank">Chapter 12 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2013&version=NASB1995" target="_blank">Chapter 13 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2014&version=NASB1995" target="_blank">Chapter 14 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2015&version=NASB1995" target="_blank">Chapter 15 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2016&version=NASB1995" target="_blank">Chapter 16 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2017&version=NASB1995" target="_blank">Chapter 17 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2018&version=NASB1995" target="_blank">Chapter 18 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2019&version=NASB1995" target="_blank">Chapter 19 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2020&version=NASB1995" target="_blank">Chapter 20 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2021&version=NASB1995" target="_blank">Chapter 21 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2022&version=NASB1995" target="_blank">Chapter 22 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2023&version=NASB1995" target="_blank">Chapter 23 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2024&version=NASB1995" target="_blank">Chapter 24 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2025&version=NASB1995" target="_blank">Chapter 25 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2026&version=NASB1995" target="_blank">Chapter 26 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2027&version=NASB1995" target="_blank">Chapter 27 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2028&version=NASB1995" target="_blank">Chapter 28 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2029&version=NASB1995" target="_blank">Chapter 29 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2030&version=NASB1995" target="_blank">Chapter 30 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2031&version=NASB1995" target="_blank">Chapter 31 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2032&version=NASB1995" target="_blank">Chapter 32 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2033&version=NASB1995" target="_blank">Chapter 33 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2034&version=NASB1995" target="_blank">Chapter 34 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2035&version=NASB1995" target="_blank">Chapter 35 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2036&version=NASB1995" target="_blank">Chapter 36 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2037&version=NASB1995" target="_blank">Chapter 37 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2038&version=NASB1995" target="_blank">Chapter 38 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2039&version=NASB1995" target="_blank">Chapter 39 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2040&version=NASB1995" target="_blank">Chapter 40 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2041&version=NASB1995" target="_blank">Chapter 41 Job (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Job%2042&version=NASB1995" target="_blank">Chapter 42 Job (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 42;

--- a/19-psalms.html
+++ b/19-psalms.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Psalms</h1>
+<body><h1>Psalms</h1>
 <p><strong>Author:</strong> Various</p>
 <p><strong>Date of Writing:</strong> 1000-400 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,175 @@
 <p>Chapters: 150</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 150.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 150</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 150 chapters, so valid results are 1-150.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%201&version=NASB1995" target="_blank">Chapter 1 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%202&version=NASB1995" target="_blank">Chapter 2 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%203&version=NASB1995" target="_blank">Chapter 3 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%204&version=NASB1995" target="_blank">Chapter 4 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%205&version=NASB1995" target="_blank">Chapter 5 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%206&version=NASB1995" target="_blank">Chapter 6 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%207&version=NASB1995" target="_blank">Chapter 7 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%208&version=NASB1995" target="_blank">Chapter 8 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%209&version=NASB1995" target="_blank">Chapter 9 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2010&version=NASB1995" target="_blank">Chapter 10 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2011&version=NASB1995" target="_blank">Chapter 11 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2012&version=NASB1995" target="_blank">Chapter 12 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2013&version=NASB1995" target="_blank">Chapter 13 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2014&version=NASB1995" target="_blank">Chapter 14 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2015&version=NASB1995" target="_blank">Chapter 15 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2016&version=NASB1995" target="_blank">Chapter 16 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2017&version=NASB1995" target="_blank">Chapter 17 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2018&version=NASB1995" target="_blank">Chapter 18 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2019&version=NASB1995" target="_blank">Chapter 19 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2020&version=NASB1995" target="_blank">Chapter 20 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2021&version=NASB1995" target="_blank">Chapter 21 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2022&version=NASB1995" target="_blank">Chapter 22 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2023&version=NASB1995" target="_blank">Chapter 23 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2024&version=NASB1995" target="_blank">Chapter 24 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2025&version=NASB1995" target="_blank">Chapter 25 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2026&version=NASB1995" target="_blank">Chapter 26 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2027&version=NASB1995" target="_blank">Chapter 27 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2028&version=NASB1995" target="_blank">Chapter 28 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2029&version=NASB1995" target="_blank">Chapter 29 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2030&version=NASB1995" target="_blank">Chapter 30 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2031&version=NASB1995" target="_blank">Chapter 31 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2032&version=NASB1995" target="_blank">Chapter 32 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2033&version=NASB1995" target="_blank">Chapter 33 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2034&version=NASB1995" target="_blank">Chapter 34 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2035&version=NASB1995" target="_blank">Chapter 35 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2036&version=NASB1995" target="_blank">Chapter 36 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2037&version=NASB1995" target="_blank">Chapter 37 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2038&version=NASB1995" target="_blank">Chapter 38 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2039&version=NASB1995" target="_blank">Chapter 39 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2040&version=NASB1995" target="_blank">Chapter 40 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2041&version=NASB1995" target="_blank">Chapter 41 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2042&version=NASB1995" target="_blank">Chapter 42 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2043&version=NASB1995" target="_blank">Chapter 43 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2044&version=NASB1995" target="_blank">Chapter 44 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2045&version=NASB1995" target="_blank">Chapter 45 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2046&version=NASB1995" target="_blank">Chapter 46 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2047&version=NASB1995" target="_blank">Chapter 47 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2048&version=NASB1995" target="_blank">Chapter 48 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2049&version=NASB1995" target="_blank">Chapter 49 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2050&version=NASB1995" target="_blank">Chapter 50 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2051&version=NASB1995" target="_blank">Chapter 51 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2052&version=NASB1995" target="_blank">Chapter 52 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2053&version=NASB1995" target="_blank">Chapter 53 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2054&version=NASB1995" target="_blank">Chapter 54 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2055&version=NASB1995" target="_blank">Chapter 55 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2056&version=NASB1995" target="_blank">Chapter 56 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2057&version=NASB1995" target="_blank">Chapter 57 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2058&version=NASB1995" target="_blank">Chapter 58 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2059&version=NASB1995" target="_blank">Chapter 59 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2060&version=NASB1995" target="_blank">Chapter 60 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2061&version=NASB1995" target="_blank">Chapter 61 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2062&version=NASB1995" target="_blank">Chapter 62 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2063&version=NASB1995" target="_blank">Chapter 63 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2064&version=NASB1995" target="_blank">Chapter 64 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2065&version=NASB1995" target="_blank">Chapter 65 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2066&version=NASB1995" target="_blank">Chapter 66 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2067&version=NASB1995" target="_blank">Chapter 67 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2068&version=NASB1995" target="_blank">Chapter 68 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2069&version=NASB1995" target="_blank">Chapter 69 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2070&version=NASB1995" target="_blank">Chapter 70 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2071&version=NASB1995" target="_blank">Chapter 71 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2072&version=NASB1995" target="_blank">Chapter 72 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2073&version=NASB1995" target="_blank">Chapter 73 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2074&version=NASB1995" target="_blank">Chapter 74 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2075&version=NASB1995" target="_blank">Chapter 75 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2076&version=NASB1995" target="_blank">Chapter 76 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2077&version=NASB1995" target="_blank">Chapter 77 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2078&version=NASB1995" target="_blank">Chapter 78 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2079&version=NASB1995" target="_blank">Chapter 79 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2080&version=NASB1995" target="_blank">Chapter 80 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2081&version=NASB1995" target="_blank">Chapter 81 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2082&version=NASB1995" target="_blank">Chapter 82 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2083&version=NASB1995" target="_blank">Chapter 83 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2084&version=NASB1995" target="_blank">Chapter 84 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2085&version=NASB1995" target="_blank">Chapter 85 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2086&version=NASB1995" target="_blank">Chapter 86 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2087&version=NASB1995" target="_blank">Chapter 87 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2088&version=NASB1995" target="_blank">Chapter 88 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2089&version=NASB1995" target="_blank">Chapter 89 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2090&version=NASB1995" target="_blank">Chapter 90 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2091&version=NASB1995" target="_blank">Chapter 91 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2092&version=NASB1995" target="_blank">Chapter 92 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2093&version=NASB1995" target="_blank">Chapter 93 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2094&version=NASB1995" target="_blank">Chapter 94 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2095&version=NASB1995" target="_blank">Chapter 95 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2096&version=NASB1995" target="_blank">Chapter 96 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2097&version=NASB1995" target="_blank">Chapter 97 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2098&version=NASB1995" target="_blank">Chapter 98 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%2099&version=NASB1995" target="_blank">Chapter 99 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20100&version=NASB1995" target="_blank">Chapter 100 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20101&version=NASB1995" target="_blank">Chapter 101 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20102&version=NASB1995" target="_blank">Chapter 102 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20103&version=NASB1995" target="_blank">Chapter 103 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20104&version=NASB1995" target="_blank">Chapter 104 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20105&version=NASB1995" target="_blank">Chapter 105 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20106&version=NASB1995" target="_blank">Chapter 106 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20107&version=NASB1995" target="_blank">Chapter 107 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20108&version=NASB1995" target="_blank">Chapter 108 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20109&version=NASB1995" target="_blank">Chapter 109 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20110&version=NASB1995" target="_blank">Chapter 110 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20111&version=NASB1995" target="_blank">Chapter 111 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20112&version=NASB1995" target="_blank">Chapter 112 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20113&version=NASB1995" target="_blank">Chapter 113 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20114&version=NASB1995" target="_blank">Chapter 114 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20115&version=NASB1995" target="_blank">Chapter 115 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20116&version=NASB1995" target="_blank">Chapter 116 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20117&version=NASB1995" target="_blank">Chapter 117 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20118&version=NASB1995" target="_blank">Chapter 118 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20119&version=NASB1995" target="_blank">Chapter 119 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20120&version=NASB1995" target="_blank">Chapter 120 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20121&version=NASB1995" target="_blank">Chapter 121 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20122&version=NASB1995" target="_blank">Chapter 122 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20123&version=NASB1995" target="_blank">Chapter 123 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20124&version=NASB1995" target="_blank">Chapter 124 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20125&version=NASB1995" target="_blank">Chapter 125 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20126&version=NASB1995" target="_blank">Chapter 126 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20127&version=NASB1995" target="_blank">Chapter 127 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20128&version=NASB1995" target="_blank">Chapter 128 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20129&version=NASB1995" target="_blank">Chapter 129 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20130&version=NASB1995" target="_blank">Chapter 130 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20131&version=NASB1995" target="_blank">Chapter 131 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20132&version=NASB1995" target="_blank">Chapter 132 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20133&version=NASB1995" target="_blank">Chapter 133 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20134&version=NASB1995" target="_blank">Chapter 134 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20135&version=NASB1995" target="_blank">Chapter 135 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20136&version=NASB1995" target="_blank">Chapter 136 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20137&version=NASB1995" target="_blank">Chapter 137 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20138&version=NASB1995" target="_blank">Chapter 138 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20139&version=NASB1995" target="_blank">Chapter 139 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20140&version=NASB1995" target="_blank">Chapter 140 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20141&version=NASB1995" target="_blank">Chapter 141 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20142&version=NASB1995" target="_blank">Chapter 142 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20143&version=NASB1995" target="_blank">Chapter 143 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20144&version=NASB1995" target="_blank">Chapter 144 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20145&version=NASB1995" target="_blank">Chapter 145 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20146&version=NASB1995" target="_blank">Chapter 146 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20147&version=NASB1995" target="_blank">Chapter 147 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20148&version=NASB1995" target="_blank">Chapter 148 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20149&version=NASB1995" target="_blank">Chapter 149 Psalms (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Psalms%20150&version=NASB1995" target="_blank">Chapter 150 Psalms (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 150;

--- a/2-exodus.html
+++ b/2-exodus.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Exodus</h1>
+<body><h1>Exodus</h1>
 <p><strong>Author:</strong> Traditionally Moses</p>
 <p><strong>Date of Writing:</strong> around 1440-1400 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,65 @@
 <p>Chapters: 40</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 40.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 40</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 40 chapters, so valid results are 1-40.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%201&version=NASB1995" target="_blank">Chapter 1 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%202&version=NASB1995" target="_blank">Chapter 2 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%203&version=NASB1995" target="_blank">Chapter 3 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%204&version=NASB1995" target="_blank">Chapter 4 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%205&version=NASB1995" target="_blank">Chapter 5 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%206&version=NASB1995" target="_blank">Chapter 6 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%207&version=NASB1995" target="_blank">Chapter 7 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%208&version=NASB1995" target="_blank">Chapter 8 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%209&version=NASB1995" target="_blank">Chapter 9 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2010&version=NASB1995" target="_blank">Chapter 10 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2011&version=NASB1995" target="_blank">Chapter 11 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2012&version=NASB1995" target="_blank">Chapter 12 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2013&version=NASB1995" target="_blank">Chapter 13 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2014&version=NASB1995" target="_blank">Chapter 14 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2015&version=NASB1995" target="_blank">Chapter 15 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2016&version=NASB1995" target="_blank">Chapter 16 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2017&version=NASB1995" target="_blank">Chapter 17 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2018&version=NASB1995" target="_blank">Chapter 18 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2019&version=NASB1995" target="_blank">Chapter 19 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2020&version=NASB1995" target="_blank">Chapter 20 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2021&version=NASB1995" target="_blank">Chapter 21 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2022&version=NASB1995" target="_blank">Chapter 22 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2023&version=NASB1995" target="_blank">Chapter 23 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2024&version=NASB1995" target="_blank">Chapter 24 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2025&version=NASB1995" target="_blank">Chapter 25 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2026&version=NASB1995" target="_blank">Chapter 26 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2027&version=NASB1995" target="_blank">Chapter 27 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2028&version=NASB1995" target="_blank">Chapter 28 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2029&version=NASB1995" target="_blank">Chapter 29 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2030&version=NASB1995" target="_blank">Chapter 30 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2031&version=NASB1995" target="_blank">Chapter 31 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2032&version=NASB1995" target="_blank">Chapter 32 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2033&version=NASB1995" target="_blank">Chapter 33 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2034&version=NASB1995" target="_blank">Chapter 34 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2035&version=NASB1995" target="_blank">Chapter 35 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2036&version=NASB1995" target="_blank">Chapter 36 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2037&version=NASB1995" target="_blank">Chapter 37 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2038&version=NASB1995" target="_blank">Chapter 38 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2039&version=NASB1995" target="_blank">Chapter 39 Exodus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Exodus%2040&version=NASB1995" target="_blank">Chapter 40 Exodus (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 40;

--- a/20-proverbs.html
+++ b/20-proverbs.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Proverbs</h1>
+<body><h1>Proverbs</h1>
 <p><strong>Author:</strong> Solomon and others</p>
 <p><strong>Date of Writing:</strong> around 900-700 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,56 @@
 <p>Chapters: 31</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 31.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 31</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 31 chapters, so valid results are 1-31.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%201&version=NASB1995" target="_blank">Chapter 1 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%202&version=NASB1995" target="_blank">Chapter 2 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%203&version=NASB1995" target="_blank">Chapter 3 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%204&version=NASB1995" target="_blank">Chapter 4 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%205&version=NASB1995" target="_blank">Chapter 5 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%206&version=NASB1995" target="_blank">Chapter 6 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%207&version=NASB1995" target="_blank">Chapter 7 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%208&version=NASB1995" target="_blank">Chapter 8 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%209&version=NASB1995" target="_blank">Chapter 9 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2010&version=NASB1995" target="_blank">Chapter 10 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2011&version=NASB1995" target="_blank">Chapter 11 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2012&version=NASB1995" target="_blank">Chapter 12 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2013&version=NASB1995" target="_blank">Chapter 13 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2014&version=NASB1995" target="_blank">Chapter 14 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2015&version=NASB1995" target="_blank">Chapter 15 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2016&version=NASB1995" target="_blank">Chapter 16 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2017&version=NASB1995" target="_blank">Chapter 17 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2018&version=NASB1995" target="_blank">Chapter 18 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2019&version=NASB1995" target="_blank">Chapter 19 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2020&version=NASB1995" target="_blank">Chapter 20 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2021&version=NASB1995" target="_blank">Chapter 21 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2022&version=NASB1995" target="_blank">Chapter 22 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2023&version=NASB1995" target="_blank">Chapter 23 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2024&version=NASB1995" target="_blank">Chapter 24 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2025&version=NASB1995" target="_blank">Chapter 25 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2026&version=NASB1995" target="_blank">Chapter 26 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2027&version=NASB1995" target="_blank">Chapter 27 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2028&version=NASB1995" target="_blank">Chapter 28 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2029&version=NASB1995" target="_blank">Chapter 29 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2030&version=NASB1995" target="_blank">Chapter 30 Proverbs (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Proverbs%2031&version=NASB1995" target="_blank">Chapter 31 Proverbs (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 31;

--- a/21-ecclesiastes.html
+++ b/21-ecclesiastes.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Ecclesiastes</h1>
+<body><h1>Ecclesiastes</h1>
 <p><strong>Author:</strong> Solomon (tradition)</p>
 <p><strong>Date of Writing:</strong> around 935 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,37 @@
 <p>Chapters: 12</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 12.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 12</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 12 chapters, so valid results are 1-12.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%201&version=NASB1995" target="_blank">Chapter 1 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%202&version=NASB1995" target="_blank">Chapter 2 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%203&version=NASB1995" target="_blank">Chapter 3 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%204&version=NASB1995" target="_blank">Chapter 4 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%205&version=NASB1995" target="_blank">Chapter 5 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%206&version=NASB1995" target="_blank">Chapter 6 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%207&version=NASB1995" target="_blank">Chapter 7 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%208&version=NASB1995" target="_blank">Chapter 8 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%209&version=NASB1995" target="_blank">Chapter 9 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%2010&version=NASB1995" target="_blank">Chapter 10 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%2011&version=NASB1995" target="_blank">Chapter 11 Ecclesiastes (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ecclesiastes%2012&version=NASB1995" target="_blank">Chapter 12 Ecclesiastes (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 12;

--- a/22-song-of-solomon.html
+++ b/22-song-of-solomon.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Song of Solomon</h1>
+<body><h1>Song of Solomon</h1>
 <p><strong>Author:</strong> Solomon (tradition)</p>
 <p><strong>Date of Writing:</strong> around 950 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,33 @@
 <p>Chapters: 8</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 8.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 8</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 8 chapters, so valid results are 1-8.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Song%20of%20Solomon%201&version=NASB1995" target="_blank">Chapter 1 Song of Solomon (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Song%20of%20Solomon%202&version=NASB1995" target="_blank">Chapter 2 Song of Solomon (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Song%20of%20Solomon%203&version=NASB1995" target="_blank">Chapter 3 Song of Solomon (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Song%20of%20Solomon%204&version=NASB1995" target="_blank">Chapter 4 Song of Solomon (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Song%20of%20Solomon%205&version=NASB1995" target="_blank">Chapter 5 Song of Solomon (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Song%20of%20Solomon%206&version=NASB1995" target="_blank">Chapter 6 Song of Solomon (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Song%20of%20Solomon%207&version=NASB1995" target="_blank">Chapter 7 Song of Solomon (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Song%20of%20Solomon%208&version=NASB1995" target="_blank">Chapter 8 Song of Solomon (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 8;

--- a/23-isaiah.html
+++ b/23-isaiah.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Isaiah</h1>
+<body><h1>Isaiah</h1>
 <p><strong>Author:</strong> Isaiah</p>
 <p><strong>Date of Writing:</strong> around 700 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,91 @@
 <p>Chapters: 66</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 66.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 66</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 66 chapters, so valid results are 1-66.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%201&version=NASB1995" target="_blank">Chapter 1 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%202&version=NASB1995" target="_blank">Chapter 2 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%203&version=NASB1995" target="_blank">Chapter 3 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%204&version=NASB1995" target="_blank">Chapter 4 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%205&version=NASB1995" target="_blank">Chapter 5 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%206&version=NASB1995" target="_blank">Chapter 6 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%207&version=NASB1995" target="_blank">Chapter 7 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%208&version=NASB1995" target="_blank">Chapter 8 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%209&version=NASB1995" target="_blank">Chapter 9 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2010&version=NASB1995" target="_blank">Chapter 10 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2011&version=NASB1995" target="_blank">Chapter 11 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2012&version=NASB1995" target="_blank">Chapter 12 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2013&version=NASB1995" target="_blank">Chapter 13 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2014&version=NASB1995" target="_blank">Chapter 14 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2015&version=NASB1995" target="_blank">Chapter 15 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2016&version=NASB1995" target="_blank">Chapter 16 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2017&version=NASB1995" target="_blank">Chapter 17 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2018&version=NASB1995" target="_blank">Chapter 18 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2019&version=NASB1995" target="_blank">Chapter 19 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2020&version=NASB1995" target="_blank">Chapter 20 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2021&version=NASB1995" target="_blank">Chapter 21 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2022&version=NASB1995" target="_blank">Chapter 22 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2023&version=NASB1995" target="_blank">Chapter 23 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2024&version=NASB1995" target="_blank">Chapter 24 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2025&version=NASB1995" target="_blank">Chapter 25 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2026&version=NASB1995" target="_blank">Chapter 26 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2027&version=NASB1995" target="_blank">Chapter 27 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2028&version=NASB1995" target="_blank">Chapter 28 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2029&version=NASB1995" target="_blank">Chapter 29 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2030&version=NASB1995" target="_blank">Chapter 30 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2031&version=NASB1995" target="_blank">Chapter 31 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2032&version=NASB1995" target="_blank">Chapter 32 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2033&version=NASB1995" target="_blank">Chapter 33 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2034&version=NASB1995" target="_blank">Chapter 34 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2035&version=NASB1995" target="_blank">Chapter 35 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2036&version=NASB1995" target="_blank">Chapter 36 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2037&version=NASB1995" target="_blank">Chapter 37 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2038&version=NASB1995" target="_blank">Chapter 38 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2039&version=NASB1995" target="_blank">Chapter 39 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2040&version=NASB1995" target="_blank">Chapter 40 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2041&version=NASB1995" target="_blank">Chapter 41 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2042&version=NASB1995" target="_blank">Chapter 42 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2043&version=NASB1995" target="_blank">Chapter 43 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2044&version=NASB1995" target="_blank">Chapter 44 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2045&version=NASB1995" target="_blank">Chapter 45 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2046&version=NASB1995" target="_blank">Chapter 46 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2047&version=NASB1995" target="_blank">Chapter 47 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2048&version=NASB1995" target="_blank">Chapter 48 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2049&version=NASB1995" target="_blank">Chapter 49 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2050&version=NASB1995" target="_blank">Chapter 50 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2051&version=NASB1995" target="_blank">Chapter 51 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2052&version=NASB1995" target="_blank">Chapter 52 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2053&version=NASB1995" target="_blank">Chapter 53 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2054&version=NASB1995" target="_blank">Chapter 54 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2055&version=NASB1995" target="_blank">Chapter 55 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2056&version=NASB1995" target="_blank">Chapter 56 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2057&version=NASB1995" target="_blank">Chapter 57 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2058&version=NASB1995" target="_blank">Chapter 58 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2059&version=NASB1995" target="_blank">Chapter 59 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2060&version=NASB1995" target="_blank">Chapter 60 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2061&version=NASB1995" target="_blank">Chapter 61 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2062&version=NASB1995" target="_blank">Chapter 62 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2063&version=NASB1995" target="_blank">Chapter 63 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2064&version=NASB1995" target="_blank">Chapter 64 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2065&version=NASB1995" target="_blank">Chapter 65 Isaiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Isaiah%2066&version=NASB1995" target="_blank">Chapter 66 Isaiah (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 66;

--- a/24-jeremiah.html
+++ b/24-jeremiah.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Jeremiah</h1>
+<body><h1>Jeremiah</h1>
 <p><strong>Author:</strong> Jeremiah</p>
 <p><strong>Date of Writing:</strong> 626-580 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,77 @@
 <p>Chapters: 52</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 52.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 52</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 52 chapters, so valid results are 1-52.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%201&version=NASB1995" target="_blank">Chapter 1 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%202&version=NASB1995" target="_blank">Chapter 2 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%203&version=NASB1995" target="_blank">Chapter 3 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%204&version=NASB1995" target="_blank">Chapter 4 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%205&version=NASB1995" target="_blank">Chapter 5 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%206&version=NASB1995" target="_blank">Chapter 6 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%207&version=NASB1995" target="_blank">Chapter 7 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%208&version=NASB1995" target="_blank">Chapter 8 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%209&version=NASB1995" target="_blank">Chapter 9 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2010&version=NASB1995" target="_blank">Chapter 10 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2011&version=NASB1995" target="_blank">Chapter 11 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2012&version=NASB1995" target="_blank">Chapter 12 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2013&version=NASB1995" target="_blank">Chapter 13 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2014&version=NASB1995" target="_blank">Chapter 14 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2015&version=NASB1995" target="_blank">Chapter 15 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2016&version=NASB1995" target="_blank">Chapter 16 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2017&version=NASB1995" target="_blank">Chapter 17 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2018&version=NASB1995" target="_blank">Chapter 18 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2019&version=NASB1995" target="_blank">Chapter 19 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2020&version=NASB1995" target="_blank">Chapter 20 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2021&version=NASB1995" target="_blank">Chapter 21 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2022&version=NASB1995" target="_blank">Chapter 22 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2023&version=NASB1995" target="_blank">Chapter 23 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2024&version=NASB1995" target="_blank">Chapter 24 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2025&version=NASB1995" target="_blank">Chapter 25 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2026&version=NASB1995" target="_blank">Chapter 26 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2027&version=NASB1995" target="_blank">Chapter 27 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2028&version=NASB1995" target="_blank">Chapter 28 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2029&version=NASB1995" target="_blank">Chapter 29 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2030&version=NASB1995" target="_blank">Chapter 30 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2031&version=NASB1995" target="_blank">Chapter 31 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2032&version=NASB1995" target="_blank">Chapter 32 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2033&version=NASB1995" target="_blank">Chapter 33 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2034&version=NASB1995" target="_blank">Chapter 34 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2035&version=NASB1995" target="_blank">Chapter 35 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2036&version=NASB1995" target="_blank">Chapter 36 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2037&version=NASB1995" target="_blank">Chapter 37 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2038&version=NASB1995" target="_blank">Chapter 38 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2039&version=NASB1995" target="_blank">Chapter 39 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2040&version=NASB1995" target="_blank">Chapter 40 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2041&version=NASB1995" target="_blank">Chapter 41 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2042&version=NASB1995" target="_blank">Chapter 42 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2043&version=NASB1995" target="_blank">Chapter 43 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2044&version=NASB1995" target="_blank">Chapter 44 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2045&version=NASB1995" target="_blank">Chapter 45 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2046&version=NASB1995" target="_blank">Chapter 46 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2047&version=NASB1995" target="_blank">Chapter 47 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2048&version=NASB1995" target="_blank">Chapter 48 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2049&version=NASB1995" target="_blank">Chapter 49 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2050&version=NASB1995" target="_blank">Chapter 50 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2051&version=NASB1995" target="_blank">Chapter 51 Jeremiah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jeremiah%2052&version=NASB1995" target="_blank">Chapter 52 Jeremiah (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 52;

--- a/25-lamentations.html
+++ b/25-lamentations.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Lamentations</h1>
+<body><h1>Lamentations</h1>
 <p><strong>Author:</strong> Jeremiah</p>
 <p><strong>Date of Writing:</strong> 586 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,30 @@
 <p>Chapters: 5</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 5.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 5</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 5 chapters, so valid results are 1-5.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Lamentations%201&version=NASB1995" target="_blank">Chapter 1 Lamentations (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Lamentations%202&version=NASB1995" target="_blank">Chapter 2 Lamentations (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Lamentations%203&version=NASB1995" target="_blank">Chapter 3 Lamentations (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Lamentations%204&version=NASB1995" target="_blank">Chapter 4 Lamentations (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Lamentations%205&version=NASB1995" target="_blank">Chapter 5 Lamentations (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 5;

--- a/26-ezekiel.html
+++ b/26-ezekiel.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Ezekiel</h1>
+<body><h1>Ezekiel</h1>
 <p><strong>Author:</strong> Ezekiel</p>
 <p><strong>Date of Writing:</strong> 593-571 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,73 @@
 <p>Chapters: 48</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 48.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 48</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 48 chapters, so valid results are 1-48.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%201&version=NASB1995" target="_blank">Chapter 1 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%202&version=NASB1995" target="_blank">Chapter 2 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%203&version=NASB1995" target="_blank">Chapter 3 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%204&version=NASB1995" target="_blank">Chapter 4 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%205&version=NASB1995" target="_blank">Chapter 5 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%206&version=NASB1995" target="_blank">Chapter 6 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%207&version=NASB1995" target="_blank">Chapter 7 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%208&version=NASB1995" target="_blank">Chapter 8 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%209&version=NASB1995" target="_blank">Chapter 9 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2010&version=NASB1995" target="_blank">Chapter 10 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2011&version=NASB1995" target="_blank">Chapter 11 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2012&version=NASB1995" target="_blank">Chapter 12 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2013&version=NASB1995" target="_blank">Chapter 13 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2014&version=NASB1995" target="_blank">Chapter 14 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2015&version=NASB1995" target="_blank">Chapter 15 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2016&version=NASB1995" target="_blank">Chapter 16 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2017&version=NASB1995" target="_blank">Chapter 17 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2018&version=NASB1995" target="_blank">Chapter 18 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2019&version=NASB1995" target="_blank">Chapter 19 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2020&version=NASB1995" target="_blank">Chapter 20 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2021&version=NASB1995" target="_blank">Chapter 21 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2022&version=NASB1995" target="_blank">Chapter 22 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2023&version=NASB1995" target="_blank">Chapter 23 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2024&version=NASB1995" target="_blank">Chapter 24 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2025&version=NASB1995" target="_blank">Chapter 25 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2026&version=NASB1995" target="_blank">Chapter 26 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2027&version=NASB1995" target="_blank">Chapter 27 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2028&version=NASB1995" target="_blank">Chapter 28 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2029&version=NASB1995" target="_blank">Chapter 29 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2030&version=NASB1995" target="_blank">Chapter 30 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2031&version=NASB1995" target="_blank">Chapter 31 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2032&version=NASB1995" target="_blank">Chapter 32 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2033&version=NASB1995" target="_blank">Chapter 33 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2034&version=NASB1995" target="_blank">Chapter 34 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2035&version=NASB1995" target="_blank">Chapter 35 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2036&version=NASB1995" target="_blank">Chapter 36 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2037&version=NASB1995" target="_blank">Chapter 37 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2038&version=NASB1995" target="_blank">Chapter 38 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2039&version=NASB1995" target="_blank">Chapter 39 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2040&version=NASB1995" target="_blank">Chapter 40 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2041&version=NASB1995" target="_blank">Chapter 41 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2042&version=NASB1995" target="_blank">Chapter 42 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2043&version=NASB1995" target="_blank">Chapter 43 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2044&version=NASB1995" target="_blank">Chapter 44 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2045&version=NASB1995" target="_blank">Chapter 45 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2046&version=NASB1995" target="_blank">Chapter 46 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2047&version=NASB1995" target="_blank">Chapter 47 Ezekiel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ezekiel%2048&version=NASB1995" target="_blank">Chapter 48 Ezekiel (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 48;

--- a/27-daniel.html
+++ b/27-daniel.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Daniel</h1>
+<body><h1>Daniel</h1>
 <p><strong>Author:</strong> Daniel</p>
 <p><strong>Date of Writing:</strong> 530 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,37 @@
 <p>Chapters: 12</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 12.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 12</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 12 chapters, so valid results are 1-12.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%201&version=NASB1995" target="_blank">Chapter 1 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%202&version=NASB1995" target="_blank">Chapter 2 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%203&version=NASB1995" target="_blank">Chapter 3 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%204&version=NASB1995" target="_blank">Chapter 4 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%205&version=NASB1995" target="_blank">Chapter 5 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%206&version=NASB1995" target="_blank">Chapter 6 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%207&version=NASB1995" target="_blank">Chapter 7 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%208&version=NASB1995" target="_blank">Chapter 8 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%209&version=NASB1995" target="_blank">Chapter 9 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%2010&version=NASB1995" target="_blank">Chapter 10 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%2011&version=NASB1995" target="_blank">Chapter 11 Daniel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Daniel%2012&version=NASB1995" target="_blank">Chapter 12 Daniel (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 12;

--- a/28-hosea.html
+++ b/28-hosea.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Hosea</h1>
+<body><h1>Hosea</h1>
 <p><strong>Author:</strong> Hosea</p>
 <p><strong>Date of Writing:</strong> about 750 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,39 @@
 <p>Chapters: 14</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 14.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 14</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 14 chapters, so valid results are 1-14.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%201&version=NASB1995" target="_blank">Chapter 1 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%202&version=NASB1995" target="_blank">Chapter 2 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%203&version=NASB1995" target="_blank">Chapter 3 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%204&version=NASB1995" target="_blank">Chapter 4 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%205&version=NASB1995" target="_blank">Chapter 5 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%206&version=NASB1995" target="_blank">Chapter 6 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%207&version=NASB1995" target="_blank">Chapter 7 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%208&version=NASB1995" target="_blank">Chapter 8 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%209&version=NASB1995" target="_blank">Chapter 9 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%2010&version=NASB1995" target="_blank">Chapter 10 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%2011&version=NASB1995" target="_blank">Chapter 11 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%2012&version=NASB1995" target="_blank">Chapter 12 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%2013&version=NASB1995" target="_blank">Chapter 13 Hosea (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hosea%2014&version=NASB1995" target="_blank">Chapter 14 Hosea (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 14;

--- a/29-joel.html
+++ b/29-joel.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Joel</h1>
+<body><h1>Joel</h1>
 <p><strong>Author:</strong> Joel</p>
 <p><strong>Date of Writing:</strong> about 800 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,28 @@
 <p>Chapters: 3</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 3</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 3 chapters, so valid results are 1-3.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Joel%201&version=NASB1995" target="_blank">Chapter 1 Joel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joel%202&version=NASB1995" target="_blank">Chapter 2 Joel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joel%203&version=NASB1995" target="_blank">Chapter 3 Joel (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 3;

--- a/3-leviticus.html
+++ b/3-leviticus.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Leviticus</h1>
+<body><h1>Leviticus</h1>
 <p><strong>Author:</strong> Traditionally Moses</p>
 <p><strong>Date of Writing:</strong> around 1440-1400 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,52 @@
 <p>Chapters: 27</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 27.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 27</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 27 chapters, so valid results are 1-27.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%201&version=NASB1995" target="_blank">Chapter 1 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%202&version=NASB1995" target="_blank">Chapter 2 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%203&version=NASB1995" target="_blank">Chapter 3 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%204&version=NASB1995" target="_blank">Chapter 4 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%205&version=NASB1995" target="_blank">Chapter 5 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%206&version=NASB1995" target="_blank">Chapter 6 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%207&version=NASB1995" target="_blank">Chapter 7 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%208&version=NASB1995" target="_blank">Chapter 8 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%209&version=NASB1995" target="_blank">Chapter 9 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2010&version=NASB1995" target="_blank">Chapter 10 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2011&version=NASB1995" target="_blank">Chapter 11 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2012&version=NASB1995" target="_blank">Chapter 12 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2013&version=NASB1995" target="_blank">Chapter 13 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2014&version=NASB1995" target="_blank">Chapter 14 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2015&version=NASB1995" target="_blank">Chapter 15 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2016&version=NASB1995" target="_blank">Chapter 16 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2017&version=NASB1995" target="_blank">Chapter 17 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2018&version=NASB1995" target="_blank">Chapter 18 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2019&version=NASB1995" target="_blank">Chapter 19 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2020&version=NASB1995" target="_blank">Chapter 20 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2021&version=NASB1995" target="_blank">Chapter 21 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2022&version=NASB1995" target="_blank">Chapter 22 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2023&version=NASB1995" target="_blank">Chapter 23 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2024&version=NASB1995" target="_blank">Chapter 24 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2025&version=NASB1995" target="_blank">Chapter 25 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2026&version=NASB1995" target="_blank">Chapter 26 Leviticus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Leviticus%2027&version=NASB1995" target="_blank">Chapter 27 Leviticus (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 27;

--- a/30-amos.html
+++ b/30-amos.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Amos</h1>
+<body><h1>Amos</h1>
 <p><strong>Author:</strong> Amos</p>
 <p><strong>Date of Writing:</strong> about 760 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,34 @@
 <p>Chapters: 9</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 9.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 9</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 9 chapters, so valid results are 1-9.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Amos%201&version=NASB1995" target="_blank">Chapter 1 Amos (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Amos%202&version=NASB1995" target="_blank">Chapter 2 Amos (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Amos%203&version=NASB1995" target="_blank">Chapter 3 Amos (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Amos%204&version=NASB1995" target="_blank">Chapter 4 Amos (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Amos%205&version=NASB1995" target="_blank">Chapter 5 Amos (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Amos%206&version=NASB1995" target="_blank">Chapter 6 Amos (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Amos%207&version=NASB1995" target="_blank">Chapter 7 Amos (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Amos%208&version=NASB1995" target="_blank">Chapter 8 Amos (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Amos%209&version=NASB1995" target="_blank">Chapter 9 Amos (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 9;

--- a/31-obadiah.html
+++ b/31-obadiah.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Obadiah</h1>
+<body><h1>Obadiah</h1>
 <p><strong>Author:</strong> Obadiah</p>
 <p><strong>Date of Writing:</strong> about 586 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,26 @@
 <p>Chapters: 1</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 1.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 1</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 1 chapter, so the only valid result is 1.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Obadiah%201&version=NASB1995" target="_blank">Chapter 1 Obadiah (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 1;

--- a/32-jonah.html
+++ b/32-jonah.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Jonah</h1>
+<body><h1>Jonah</h1>
 <p><strong>Author:</strong> Jonah</p>
 <p><strong>Date of Writing:</strong> about 760 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,29 @@
 <p>Chapters: 4</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 4</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 4 chapters, so valid results are 1-4.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Jonah%201&version=NASB1995" target="_blank">Chapter 1 Jonah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jonah%202&version=NASB1995" target="_blank">Chapter 2 Jonah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jonah%203&version=NASB1995" target="_blank">Chapter 3 Jonah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Jonah%204&version=NASB1995" target="_blank">Chapter 4 Jonah (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 4;

--- a/33-micah.html
+++ b/33-micah.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Micah</h1>
+<body><h1>Micah</h1>
 <p><strong>Author:</strong> Micah</p>
 <p><strong>Date of Writing:</strong> about 700 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,32 @@
 <p>Chapters: 7</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 7.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 7</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 7 chapters, so valid results are 1-7.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Micah%201&version=NASB1995" target="_blank">Chapter 1 Micah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Micah%202&version=NASB1995" target="_blank">Chapter 2 Micah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Micah%203&version=NASB1995" target="_blank">Chapter 3 Micah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Micah%204&version=NASB1995" target="_blank">Chapter 4 Micah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Micah%205&version=NASB1995" target="_blank">Chapter 5 Micah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Micah%206&version=NASB1995" target="_blank">Chapter 6 Micah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Micah%207&version=NASB1995" target="_blank">Chapter 7 Micah (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 7;

--- a/34-nahum.html
+++ b/34-nahum.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Nahum</h1>
+<body><h1>Nahum</h1>
 <p><strong>Author:</strong> Nahum</p>
 <p><strong>Date of Writing:</strong> about 650 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,28 @@
 <p>Chapters: 3</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 3</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 3 chapters, so valid results are 1-3.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Nahum%201&version=NASB1995" target="_blank">Chapter 1 Nahum (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nahum%202&version=NASB1995" target="_blank">Chapter 2 Nahum (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Nahum%203&version=NASB1995" target="_blank">Chapter 3 Nahum (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 3;

--- a/35-habakkuk.html
+++ b/35-habakkuk.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Habakkuk</h1>
+<body><h1>Habakkuk</h1>
 <p><strong>Author:</strong> Habakkuk</p>
 <p><strong>Date of Writing:</strong> about 600 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,28 @@
 <p>Chapters: 3</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 3</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 3 chapters, so valid results are 1-3.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Habakkuk%201&version=NASB1995" target="_blank">Chapter 1 Habakkuk (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Habakkuk%202&version=NASB1995" target="_blank">Chapter 2 Habakkuk (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Habakkuk%203&version=NASB1995" target="_blank">Chapter 3 Habakkuk (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 3;

--- a/36-zephaniah.html
+++ b/36-zephaniah.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Zephaniah</h1>
+<body><h1>Zephaniah</h1>
 <p><strong>Author:</strong> Zephaniah</p>
 <p><strong>Date of Writing:</strong> about 640 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,28 @@
 <p>Chapters: 3</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 3</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 3 chapters, so valid results are 1-3.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Zephaniah%201&version=NASB1995" target="_blank">Chapter 1 Zephaniah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zephaniah%202&version=NASB1995" target="_blank">Chapter 2 Zephaniah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zephaniah%203&version=NASB1995" target="_blank">Chapter 3 Zephaniah (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 3;

--- a/37-haggai.html
+++ b/37-haggai.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Haggai</h1>
+<body><h1>Haggai</h1>
 <p><strong>Author:</strong> Haggai</p>
 <p><strong>Date of Writing:</strong> 520 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,27 @@
 <p>Chapters: 2</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 2.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 2</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 2 chapters, so valid results are 1-2.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Haggai%201&version=NASB1995" target="_blank">Chapter 1 Haggai (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Haggai%202&version=NASB1995" target="_blank">Chapter 2 Haggai (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 2;

--- a/38-zechariah.html
+++ b/38-zechariah.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Zechariah</h1>
+<body><h1>Zechariah</h1>
 <p><strong>Author:</strong> Zechariah</p>
 <p><strong>Date of Writing:</strong> 520-480 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,39 @@
 <p>Chapters: 14</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 14.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 14</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 14 chapters, so valid results are 1-14.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%201&version=NASB1995" target="_blank">Chapter 1 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%202&version=NASB1995" target="_blank">Chapter 2 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%203&version=NASB1995" target="_blank">Chapter 3 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%204&version=NASB1995" target="_blank">Chapter 4 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%205&version=NASB1995" target="_blank">Chapter 5 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%206&version=NASB1995" target="_blank">Chapter 6 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%207&version=NASB1995" target="_blank">Chapter 7 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%208&version=NASB1995" target="_blank">Chapter 8 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%209&version=NASB1995" target="_blank">Chapter 9 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%2010&version=NASB1995" target="_blank">Chapter 10 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%2011&version=NASB1995" target="_blank">Chapter 11 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%2012&version=NASB1995" target="_blank">Chapter 12 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%2013&version=NASB1995" target="_blank">Chapter 13 Zechariah (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Zechariah%2014&version=NASB1995" target="_blank">Chapter 14 Zechariah (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 14;

--- a/39-malachi.html
+++ b/39-malachi.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Malachi</h1>
+<body><h1>Malachi</h1>
 <p><strong>Author:</strong> Malachi</p>
 <p><strong>Date of Writing:</strong> around 430 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,29 @@
 <p>Chapters: 4</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 4</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 4 chapters, so valid results are 1-4.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Malachi%201&version=NASB1995" target="_blank">Chapter 1 Malachi (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Malachi%202&version=NASB1995" target="_blank">Chapter 2 Malachi (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Malachi%203&version=NASB1995" target="_blank">Chapter 3 Malachi (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Malachi%204&version=NASB1995" target="_blank">Chapter 4 Malachi (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 4;

--- a/4-numbers.html
+++ b/4-numbers.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Numbers</h1>
+<body><h1>Numbers</h1>
 <p><strong>Author:</strong> Traditionally Moses</p>
 <p><strong>Date of Writing:</strong> around 1440-1400 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,61 @@
 <p>Chapters: 36</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 36.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 36</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 36 chapters, so valid results are 1-36.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%201&version=NASB1995" target="_blank">Chapter 1 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%202&version=NASB1995" target="_blank">Chapter 2 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%203&version=NASB1995" target="_blank">Chapter 3 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%204&version=NASB1995" target="_blank">Chapter 4 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%205&version=NASB1995" target="_blank">Chapter 5 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%206&version=NASB1995" target="_blank">Chapter 6 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%207&version=NASB1995" target="_blank">Chapter 7 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%208&version=NASB1995" target="_blank">Chapter 8 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%209&version=NASB1995" target="_blank">Chapter 9 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2010&version=NASB1995" target="_blank">Chapter 10 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2011&version=NASB1995" target="_blank">Chapter 11 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2012&version=NASB1995" target="_blank">Chapter 12 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2013&version=NASB1995" target="_blank">Chapter 13 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2014&version=NASB1995" target="_blank">Chapter 14 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2015&version=NASB1995" target="_blank">Chapter 15 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2016&version=NASB1995" target="_blank">Chapter 16 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2017&version=NASB1995" target="_blank">Chapter 17 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2018&version=NASB1995" target="_blank">Chapter 18 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2019&version=NASB1995" target="_blank">Chapter 19 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2020&version=NASB1995" target="_blank">Chapter 20 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2021&version=NASB1995" target="_blank">Chapter 21 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2022&version=NASB1995" target="_blank">Chapter 22 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2023&version=NASB1995" target="_blank">Chapter 23 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2024&version=NASB1995" target="_blank">Chapter 24 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2025&version=NASB1995" target="_blank">Chapter 25 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2026&version=NASB1995" target="_blank">Chapter 26 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2027&version=NASB1995" target="_blank">Chapter 27 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2028&version=NASB1995" target="_blank">Chapter 28 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2029&version=NASB1995" target="_blank">Chapter 29 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2030&version=NASB1995" target="_blank">Chapter 30 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2031&version=NASB1995" target="_blank">Chapter 31 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2032&version=NASB1995" target="_blank">Chapter 32 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2033&version=NASB1995" target="_blank">Chapter 33 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2034&version=NASB1995" target="_blank">Chapter 34 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2035&version=NASB1995" target="_blank">Chapter 35 Numbers (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Numbers%2036&version=NASB1995" target="_blank">Chapter 36 Numbers (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 36;

--- a/40-matthew.html
+++ b/40-matthew.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Matthew</h1>
+<body><h1>Matthew</h1>
 <p><strong>Author:</strong> Matthew</p>
 <p><strong>Date of Writing:</strong> A.D. 50-60</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,53 @@
 <p>Chapters: 28</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 28.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 28</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 28 chapters, so valid results are 1-28.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%201&version=NASB1995" target="_blank">Chapter 1 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%202&version=NASB1995" target="_blank">Chapter 2 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%203&version=NASB1995" target="_blank">Chapter 3 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%204&version=NASB1995" target="_blank">Chapter 4 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%205&version=NASB1995" target="_blank">Chapter 5 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%206&version=NASB1995" target="_blank">Chapter 6 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%207&version=NASB1995" target="_blank">Chapter 7 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%208&version=NASB1995" target="_blank">Chapter 8 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%209&version=NASB1995" target="_blank">Chapter 9 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2010&version=NASB1995" target="_blank">Chapter 10 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2011&version=NASB1995" target="_blank">Chapter 11 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2012&version=NASB1995" target="_blank">Chapter 12 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2013&version=NASB1995" target="_blank">Chapter 13 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2014&version=NASB1995" target="_blank">Chapter 14 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2015&version=NASB1995" target="_blank">Chapter 15 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2016&version=NASB1995" target="_blank">Chapter 16 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2017&version=NASB1995" target="_blank">Chapter 17 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2018&version=NASB1995" target="_blank">Chapter 18 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2019&version=NASB1995" target="_blank">Chapter 19 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2020&version=NASB1995" target="_blank">Chapter 20 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2021&version=NASB1995" target="_blank">Chapter 21 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2022&version=NASB1995" target="_blank">Chapter 22 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2023&version=NASB1995" target="_blank">Chapter 23 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2024&version=NASB1995" target="_blank">Chapter 24 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2025&version=NASB1995" target="_blank">Chapter 25 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2026&version=NASB1995" target="_blank">Chapter 26 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2027&version=NASB1995" target="_blank">Chapter 27 Matthew (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Matthew%2028&version=NASB1995" target="_blank">Chapter 28 Matthew (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 28;

--- a/41-mark.html
+++ b/41-mark.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Mark</h1>
+<body><h1>Mark</h1>
 <p><strong>Author:</strong> Mark</p>
 <p><strong>Date of Writing:</strong> A.D. 50-60</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,41 @@
 <p>Chapters: 16</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 16.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 16</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 16 chapters, so valid results are 1-16.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Mark%201&version=NASB1995" target="_blank">Chapter 1 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%202&version=NASB1995" target="_blank">Chapter 2 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%203&version=NASB1995" target="_blank">Chapter 3 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%204&version=NASB1995" target="_blank">Chapter 4 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%205&version=NASB1995" target="_blank">Chapter 5 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%206&version=NASB1995" target="_blank">Chapter 6 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%207&version=NASB1995" target="_blank">Chapter 7 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%208&version=NASB1995" target="_blank">Chapter 8 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%209&version=NASB1995" target="_blank">Chapter 9 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%2010&version=NASB1995" target="_blank">Chapter 10 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%2011&version=NASB1995" target="_blank">Chapter 11 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%2012&version=NASB1995" target="_blank">Chapter 12 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%2013&version=NASB1995" target="_blank">Chapter 13 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%2014&version=NASB1995" target="_blank">Chapter 14 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%2015&version=NASB1995" target="_blank">Chapter 15 Mark (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Mark%2016&version=NASB1995" target="_blank">Chapter 16 Mark (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 16;

--- a/42-luke.html
+++ b/42-luke.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Luke</h1>
+<body><h1>Luke</h1>
 <p><strong>Author:</strong> Luke</p>
 <p><strong>Date of Writing:</strong> A.D. 60</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,49 @@
 <p>Chapters: 24</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 24.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 24</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 24 chapters, so valid results are 1-24.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Luke%201&version=NASB1995" target="_blank">Chapter 1 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%202&version=NASB1995" target="_blank">Chapter 2 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%203&version=NASB1995" target="_blank">Chapter 3 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%204&version=NASB1995" target="_blank">Chapter 4 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%205&version=NASB1995" target="_blank">Chapter 5 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%206&version=NASB1995" target="_blank">Chapter 6 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%207&version=NASB1995" target="_blank">Chapter 7 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%208&version=NASB1995" target="_blank">Chapter 8 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%209&version=NASB1995" target="_blank">Chapter 9 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2010&version=NASB1995" target="_blank">Chapter 10 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2011&version=NASB1995" target="_blank">Chapter 11 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2012&version=NASB1995" target="_blank">Chapter 12 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2013&version=NASB1995" target="_blank">Chapter 13 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2014&version=NASB1995" target="_blank">Chapter 14 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2015&version=NASB1995" target="_blank">Chapter 15 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2016&version=NASB1995" target="_blank">Chapter 16 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2017&version=NASB1995" target="_blank">Chapter 17 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2018&version=NASB1995" target="_blank">Chapter 18 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2019&version=NASB1995" target="_blank">Chapter 19 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2020&version=NASB1995" target="_blank">Chapter 20 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2021&version=NASB1995" target="_blank">Chapter 21 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2022&version=NASB1995" target="_blank">Chapter 22 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2023&version=NASB1995" target="_blank">Chapter 23 Luke (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Luke%2024&version=NASB1995" target="_blank">Chapter 24 Luke (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 24;

--- a/43-john.html
+++ b/43-john.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>John</h1>
+<body><h1>John</h1>
 <p><strong>Author:</strong> John</p>
 <p><strong>Date of Writing:</strong> A.D. 80-90</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,46 @@
 <p>Chapters: 21</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 21.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 21</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 21 chapters, so valid results are 1-21.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=John%201&version=NASB1995" target="_blank">Chapter 1 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%202&version=NASB1995" target="_blank">Chapter 2 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%203&version=NASB1995" target="_blank">Chapter 3 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%204&version=NASB1995" target="_blank">Chapter 4 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%205&version=NASB1995" target="_blank">Chapter 5 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%206&version=NASB1995" target="_blank">Chapter 6 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%207&version=NASB1995" target="_blank">Chapter 7 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%208&version=NASB1995" target="_blank">Chapter 8 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%209&version=NASB1995" target="_blank">Chapter 9 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2010&version=NASB1995" target="_blank">Chapter 10 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2011&version=NASB1995" target="_blank">Chapter 11 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2012&version=NASB1995" target="_blank">Chapter 12 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2013&version=NASB1995" target="_blank">Chapter 13 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2014&version=NASB1995" target="_blank">Chapter 14 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2015&version=NASB1995" target="_blank">Chapter 15 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2016&version=NASB1995" target="_blank">Chapter 16 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2017&version=NASB1995" target="_blank">Chapter 17 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2018&version=NASB1995" target="_blank">Chapter 18 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2019&version=NASB1995" target="_blank">Chapter 19 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2020&version=NASB1995" target="_blank">Chapter 20 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=John%2021&version=NASB1995" target="_blank">Chapter 21 John (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 21;

--- a/44-acts.html
+++ b/44-acts.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Acts</h1>
+<body><h1>Acts</h1>
 <p><strong>Author:</strong> Luke</p>
 <p><strong>Date of Writing:</strong> A.D. 62</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,53 @@
 <p>Chapters: 28</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 28.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 28</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 28 chapters, so valid results are 1-28.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Acts%201&version=NASB1995" target="_blank">Chapter 1 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%202&version=NASB1995" target="_blank">Chapter 2 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%203&version=NASB1995" target="_blank">Chapter 3 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%204&version=NASB1995" target="_blank">Chapter 4 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%205&version=NASB1995" target="_blank">Chapter 5 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%206&version=NASB1995" target="_blank">Chapter 6 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%207&version=NASB1995" target="_blank">Chapter 7 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%208&version=NASB1995" target="_blank">Chapter 8 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%209&version=NASB1995" target="_blank">Chapter 9 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2010&version=NASB1995" target="_blank">Chapter 10 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2011&version=NASB1995" target="_blank">Chapter 11 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2012&version=NASB1995" target="_blank">Chapter 12 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2013&version=NASB1995" target="_blank">Chapter 13 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2014&version=NASB1995" target="_blank">Chapter 14 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2015&version=NASB1995" target="_blank">Chapter 15 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2016&version=NASB1995" target="_blank">Chapter 16 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2017&version=NASB1995" target="_blank">Chapter 17 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2018&version=NASB1995" target="_blank">Chapter 18 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2019&version=NASB1995" target="_blank">Chapter 19 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2020&version=NASB1995" target="_blank">Chapter 20 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2021&version=NASB1995" target="_blank">Chapter 21 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2022&version=NASB1995" target="_blank">Chapter 22 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2023&version=NASB1995" target="_blank">Chapter 23 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2024&version=NASB1995" target="_blank">Chapter 24 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2025&version=NASB1995" target="_blank">Chapter 25 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2026&version=NASB1995" target="_blank">Chapter 26 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2027&version=NASB1995" target="_blank">Chapter 27 Acts (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Acts%2028&version=NASB1995" target="_blank">Chapter 28 Acts (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 28;

--- a/45-romans.html
+++ b/45-romans.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Romans</h1>
+<body><h1>Romans</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 57</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,41 @@
 <p>Chapters: 16</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 16.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 16</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 16 chapters, so valid results are 1-16.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Romans%201&version=NASB1995" target="_blank">Chapter 1 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%202&version=NASB1995" target="_blank">Chapter 2 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%203&version=NASB1995" target="_blank">Chapter 3 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%204&version=NASB1995" target="_blank">Chapter 4 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%205&version=NASB1995" target="_blank">Chapter 5 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%206&version=NASB1995" target="_blank">Chapter 6 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%207&version=NASB1995" target="_blank">Chapter 7 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%208&version=NASB1995" target="_blank">Chapter 8 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%209&version=NASB1995" target="_blank">Chapter 9 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%2010&version=NASB1995" target="_blank">Chapter 10 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%2011&version=NASB1995" target="_blank">Chapter 11 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%2012&version=NASB1995" target="_blank">Chapter 12 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%2013&version=NASB1995" target="_blank">Chapter 13 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%2014&version=NASB1995" target="_blank">Chapter 14 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%2015&version=NASB1995" target="_blank">Chapter 15 Romans (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Romans%2016&version=NASB1995" target="_blank">Chapter 16 Romans (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 16;

--- a/46-1-corinthians.html
+++ b/46-1-corinthians.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>1 Corinthians</h1>
+<body><h1>1 Corinthians</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 55</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,41 @@
 <p>Chapters: 16</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 16.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 16</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 16 chapters, so valid results are 1-16.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%201&version=NASB1995" target="_blank">Chapter 1 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%202&version=NASB1995" target="_blank">Chapter 2 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%203&version=NASB1995" target="_blank">Chapter 3 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%204&version=NASB1995" target="_blank">Chapter 4 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%205&version=NASB1995" target="_blank">Chapter 5 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%206&version=NASB1995" target="_blank">Chapter 6 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%207&version=NASB1995" target="_blank">Chapter 7 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%208&version=NASB1995" target="_blank">Chapter 8 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%209&version=NASB1995" target="_blank">Chapter 9 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%2010&version=NASB1995" target="_blank">Chapter 10 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%2011&version=NASB1995" target="_blank">Chapter 11 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%2012&version=NASB1995" target="_blank">Chapter 12 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%2013&version=NASB1995" target="_blank">Chapter 13 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%2014&version=NASB1995" target="_blank">Chapter 14 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%2015&version=NASB1995" target="_blank">Chapter 15 1 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Corinthians%2016&version=NASB1995" target="_blank">Chapter 16 1 Corinthians (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 16;

--- a/47-2-corinthians.html
+++ b/47-2-corinthians.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>2 Corinthians</h1>
+<body><h1>2 Corinthians</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 55-56</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,38 @@
 <p>Chapters: 13</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 13.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 13</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 13 chapters, so valid results are 1-13.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%201&version=NASB1995" target="_blank">Chapter 1 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%202&version=NASB1995" target="_blank">Chapter 2 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%203&version=NASB1995" target="_blank">Chapter 3 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%204&version=NASB1995" target="_blank">Chapter 4 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%205&version=NASB1995" target="_blank">Chapter 5 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%206&version=NASB1995" target="_blank">Chapter 6 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%207&version=NASB1995" target="_blank">Chapter 7 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%208&version=NASB1995" target="_blank">Chapter 8 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%209&version=NASB1995" target="_blank">Chapter 9 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%2010&version=NASB1995" target="_blank">Chapter 10 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%2011&version=NASB1995" target="_blank">Chapter 11 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%2012&version=NASB1995" target="_blank">Chapter 12 2 Corinthians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Corinthians%2013&version=NASB1995" target="_blank">Chapter 13 2 Corinthians (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 13;

--- a/48-galatians.html
+++ b/48-galatians.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Galatians</h1>
+<body><h1>Galatians</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 49</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,31 @@
 <p>Chapters: 6</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 6.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 6</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 6 chapters, so valid results are 1-6.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Galatians%201&version=NASB1995" target="_blank">Chapter 1 Galatians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Galatians%202&version=NASB1995" target="_blank">Chapter 2 Galatians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Galatians%203&version=NASB1995" target="_blank">Chapter 3 Galatians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Galatians%204&version=NASB1995" target="_blank">Chapter 4 Galatians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Galatians%205&version=NASB1995" target="_blank">Chapter 5 Galatians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Galatians%206&version=NASB1995" target="_blank">Chapter 6 Galatians (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 6;

--- a/49-ephesians.html
+++ b/49-ephesians.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Ephesians</h1>
+<body><h1>Ephesians</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 60</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,31 @@
 <p>Chapters: 6</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 6.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 6</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 6 chapters, so valid results are 1-6.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Ephesians%201&version=NASB1995" target="_blank">Chapter 1 Ephesians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ephesians%202&version=NASB1995" target="_blank">Chapter 2 Ephesians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ephesians%203&version=NASB1995" target="_blank">Chapter 3 Ephesians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ephesians%204&version=NASB1995" target="_blank">Chapter 4 Ephesians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ephesians%205&version=NASB1995" target="_blank">Chapter 5 Ephesians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ephesians%206&version=NASB1995" target="_blank">Chapter 6 Ephesians (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 6;

--- a/5-deuteronomy.html
+++ b/5-deuteronomy.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Deuteronomy</h1>
+<body><h1>Deuteronomy</h1>
 <p><strong>Author:</strong> Traditionally Moses</p>
 <p><strong>Date of Writing:</strong> around 1400 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,59 @@
 <p>Chapters: 34</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 34.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 34</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 34 chapters, so valid results are 1-34.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%201&version=NASB1995" target="_blank">Chapter 1 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%202&version=NASB1995" target="_blank">Chapter 2 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%203&version=NASB1995" target="_blank">Chapter 3 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%204&version=NASB1995" target="_blank">Chapter 4 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%205&version=NASB1995" target="_blank">Chapter 5 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%206&version=NASB1995" target="_blank">Chapter 6 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%207&version=NASB1995" target="_blank">Chapter 7 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%208&version=NASB1995" target="_blank">Chapter 8 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%209&version=NASB1995" target="_blank">Chapter 9 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2010&version=NASB1995" target="_blank">Chapter 10 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2011&version=NASB1995" target="_blank">Chapter 11 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2012&version=NASB1995" target="_blank">Chapter 12 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2013&version=NASB1995" target="_blank">Chapter 13 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2014&version=NASB1995" target="_blank">Chapter 14 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2015&version=NASB1995" target="_blank">Chapter 15 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2016&version=NASB1995" target="_blank">Chapter 16 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2017&version=NASB1995" target="_blank">Chapter 17 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2018&version=NASB1995" target="_blank">Chapter 18 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2019&version=NASB1995" target="_blank">Chapter 19 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2020&version=NASB1995" target="_blank">Chapter 20 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2021&version=NASB1995" target="_blank">Chapter 21 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2022&version=NASB1995" target="_blank">Chapter 22 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2023&version=NASB1995" target="_blank">Chapter 23 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2024&version=NASB1995" target="_blank">Chapter 24 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2025&version=NASB1995" target="_blank">Chapter 25 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2026&version=NASB1995" target="_blank">Chapter 26 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2027&version=NASB1995" target="_blank">Chapter 27 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2028&version=NASB1995" target="_blank">Chapter 28 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2029&version=NASB1995" target="_blank">Chapter 29 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2030&version=NASB1995" target="_blank">Chapter 30 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2031&version=NASB1995" target="_blank">Chapter 31 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2032&version=NASB1995" target="_blank">Chapter 32 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2033&version=NASB1995" target="_blank">Chapter 33 Deuteronomy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Deuteronomy%2034&version=NASB1995" target="_blank">Chapter 34 Deuteronomy (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 34;

--- a/50-philippians.html
+++ b/50-philippians.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Philippians</h1>
+<body><h1>Philippians</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 60</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,29 @@
 <p>Chapters: 4</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 4</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 4 chapters, so valid results are 1-4.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Philippians%201&version=NASB1995" target="_blank">Chapter 1 Philippians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Philippians%202&version=NASB1995" target="_blank">Chapter 2 Philippians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Philippians%203&version=NASB1995" target="_blank">Chapter 3 Philippians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Philippians%204&version=NASB1995" target="_blank">Chapter 4 Philippians (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 4;

--- a/51-colossians.html
+++ b/51-colossians.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Colossians</h1>
+<body><h1>Colossians</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 60</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,29 @@
 <p>Chapters: 4</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 4</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 4 chapters, so valid results are 1-4.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Colossians%201&version=NASB1995" target="_blank">Chapter 1 Colossians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Colossians%202&version=NASB1995" target="_blank">Chapter 2 Colossians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Colossians%203&version=NASB1995" target="_blank">Chapter 3 Colossians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Colossians%204&version=NASB1995" target="_blank">Chapter 4 Colossians (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 4;

--- a/52-1-thessalonians.html
+++ b/52-1-thessalonians.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>1 Thessalonians</h1>
+<body><h1>1 Thessalonians</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 51</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,30 @@
 <p>Chapters: 5</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 5.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 5</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 5 chapters, so valid results are 1-5.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=1%20Thessalonians%201&version=NASB1995" target="_blank">Chapter 1 1 Thessalonians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Thessalonians%202&version=NASB1995" target="_blank">Chapter 2 1 Thessalonians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Thessalonians%203&version=NASB1995" target="_blank">Chapter 3 1 Thessalonians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Thessalonians%204&version=NASB1995" target="_blank">Chapter 4 1 Thessalonians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Thessalonians%205&version=NASB1995" target="_blank">Chapter 5 1 Thessalonians (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 5;

--- a/53-2-thessalonians.html
+++ b/53-2-thessalonians.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>2 Thessalonians</h1>
+<body><h1>2 Thessalonians</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 51-52</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,28 @@
 <p>Chapters: 3</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 3</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 3 chapters, so valid results are 1-3.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=2%20Thessalonians%201&version=NASB1995" target="_blank">Chapter 1 2 Thessalonians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Thessalonians%202&version=NASB1995" target="_blank">Chapter 2 2 Thessalonians (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Thessalonians%203&version=NASB1995" target="_blank">Chapter 3 2 Thessalonians (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 3;

--- a/54-1-timothy.html
+++ b/54-1-timothy.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>1 Timothy</h1>
+<body><h1>1 Timothy</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 62-64</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,31 @@
 <p>Chapters: 6</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 6.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 6</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 6 chapters, so valid results are 1-6.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=1%20Timothy%201&version=NASB1995" target="_blank">Chapter 1 1 Timothy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Timothy%202&version=NASB1995" target="_blank">Chapter 2 1 Timothy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Timothy%203&version=NASB1995" target="_blank">Chapter 3 1 Timothy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Timothy%204&version=NASB1995" target="_blank">Chapter 4 1 Timothy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Timothy%205&version=NASB1995" target="_blank">Chapter 5 1 Timothy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Timothy%206&version=NASB1995" target="_blank">Chapter 6 1 Timothy (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 6;

--- a/55-2-timothy.html
+++ b/55-2-timothy.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>2 Timothy</h1>
+<body><h1>2 Timothy</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 64-67</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,29 @@
 <p>Chapters: 4</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 4</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 4 chapters, so valid results are 1-4.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=2%20Timothy%201&version=NASB1995" target="_blank">Chapter 1 2 Timothy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Timothy%202&version=NASB1995" target="_blank">Chapter 2 2 Timothy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Timothy%203&version=NASB1995" target="_blank">Chapter 3 2 Timothy (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Timothy%204&version=NASB1995" target="_blank">Chapter 4 2 Timothy (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 4;

--- a/56-titus.html
+++ b/56-titus.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Titus</h1>
+<body><h1>Titus</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 63</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,28 @@
 <p>Chapters: 3</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 3</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 3 chapters, so valid results are 1-3.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Titus%201&version=NASB1995" target="_blank">Chapter 1 Titus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Titus%202&version=NASB1995" target="_blank">Chapter 2 Titus (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Titus%203&version=NASB1995" target="_blank">Chapter 3 Titus (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 3;

--- a/57-philemon.html
+++ b/57-philemon.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Philemon</h1>
+<body><h1>Philemon</h1>
 <p><strong>Author:</strong> Paul</p>
 <p><strong>Date of Writing:</strong> A.D. 60</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,26 @@
 <p>Chapters: 1</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 1.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 1</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 1 chapter, so the only valid result is 1.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Philemon%201&version=NASB1995" target="_blank">Chapter 1 Philemon (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 1;

--- a/58-hebrews.html
+++ b/58-hebrews.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Hebrews</h1>
+<body><h1>Hebrews</h1>
 <p><strong>Author:</strong> Unknown</p>
 <p><strong>Date of Writing:</strong> A.D. 60-70</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,38 @@
 <p>Chapters: 13</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 13.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 13</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 13 chapters, so valid results are 1-13.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%201&version=NASB1995" target="_blank">Chapter 1 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%202&version=NASB1995" target="_blank">Chapter 2 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%203&version=NASB1995" target="_blank">Chapter 3 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%204&version=NASB1995" target="_blank">Chapter 4 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%205&version=NASB1995" target="_blank">Chapter 5 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%206&version=NASB1995" target="_blank">Chapter 6 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%207&version=NASB1995" target="_blank">Chapter 7 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%208&version=NASB1995" target="_blank">Chapter 8 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%209&version=NASB1995" target="_blank">Chapter 9 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%2010&version=NASB1995" target="_blank">Chapter 10 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%2011&version=NASB1995" target="_blank">Chapter 11 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%2012&version=NASB1995" target="_blank">Chapter 12 Hebrews (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Hebrews%2013&version=NASB1995" target="_blank">Chapter 13 Hebrews (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 13;

--- a/59-james.html
+++ b/59-james.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>James</h1>
+<body><h1>James</h1>
 <p><strong>Author:</strong> James</p>
 <p><strong>Date of Writing:</strong> A.D. 40-50</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,30 @@
 <p>Chapters: 5</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 5.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 5</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 5 chapters, so valid results are 1-5.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=James%201&version=NASB1995" target="_blank">Chapter 1 James (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=James%202&version=NASB1995" target="_blank">Chapter 2 James (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=James%203&version=NASB1995" target="_blank">Chapter 3 James (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=James%204&version=NASB1995" target="_blank">Chapter 4 James (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=James%205&version=NASB1995" target="_blank">Chapter 5 James (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 5;

--- a/6-joshua.html
+++ b/6-joshua.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Joshua</h1>
+<body><h1>Joshua</h1>
 <p><strong>Author:</strong> Joshua</p>
 <p><strong>Date of Writing:</strong> about 1400-1370 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,49 @@
 <p>Chapters: 24</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 24.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 24</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 24 chapters, so valid results are 1-24.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%201&version=NASB1995" target="_blank">Chapter 1 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%202&version=NASB1995" target="_blank">Chapter 2 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%203&version=NASB1995" target="_blank">Chapter 3 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%204&version=NASB1995" target="_blank">Chapter 4 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%205&version=NASB1995" target="_blank">Chapter 5 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%206&version=NASB1995" target="_blank">Chapter 6 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%207&version=NASB1995" target="_blank">Chapter 7 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%208&version=NASB1995" target="_blank">Chapter 8 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%209&version=NASB1995" target="_blank">Chapter 9 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2010&version=NASB1995" target="_blank">Chapter 10 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2011&version=NASB1995" target="_blank">Chapter 11 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2012&version=NASB1995" target="_blank">Chapter 12 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2013&version=NASB1995" target="_blank">Chapter 13 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2014&version=NASB1995" target="_blank">Chapter 14 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2015&version=NASB1995" target="_blank">Chapter 15 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2016&version=NASB1995" target="_blank">Chapter 16 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2017&version=NASB1995" target="_blank">Chapter 17 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2018&version=NASB1995" target="_blank">Chapter 18 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2019&version=NASB1995" target="_blank">Chapter 19 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2020&version=NASB1995" target="_blank">Chapter 20 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2021&version=NASB1995" target="_blank">Chapter 21 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2022&version=NASB1995" target="_blank">Chapter 22 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2023&version=NASB1995" target="_blank">Chapter 23 Joshua (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Joshua%2024&version=NASB1995" target="_blank">Chapter 24 Joshua (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 24;

--- a/60-1-peter.html
+++ b/60-1-peter.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>1 Peter</h1>
+<body><h1>1 Peter</h1>
 <p><strong>Author:</strong> Peter</p>
 <p><strong>Date of Writing:</strong> A.D. 60</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,30 @@
 <p>Chapters: 5</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 5.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 5</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 5 chapters, so valid results are 1-5.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=1%20Peter%201&version=NASB1995" target="_blank">Chapter 1 1 Peter (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Peter%202&version=NASB1995" target="_blank">Chapter 2 1 Peter (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Peter%203&version=NASB1995" target="_blank">Chapter 3 1 Peter (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Peter%204&version=NASB1995" target="_blank">Chapter 4 1 Peter (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Peter%205&version=NASB1995" target="_blank">Chapter 5 1 Peter (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 5;

--- a/61-2-peter.html
+++ b/61-2-peter.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>2 Peter</h1>
+<body><h1>2 Peter</h1>
 <p><strong>Author:</strong> Peter</p>
 <p><strong>Date of Writing:</strong> A.D. 60-68</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,28 @@
 <p>Chapters: 3</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 3.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 3</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 3 chapters, so valid results are 1-3.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=2%20Peter%201&version=NASB1995" target="_blank">Chapter 1 2 Peter (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Peter%202&version=NASB1995" target="_blank">Chapter 2 2 Peter (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=2%20Peter%203&version=NASB1995" target="_blank">Chapter 3 2 Peter (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 3;

--- a/62-1-john.html
+++ b/62-1-john.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>1 John</h1>
+<body><h1>1 John</h1>
 <p><strong>Author:</strong> John</p>
 <p><strong>Date of Writing:</strong> A.D. 85-95</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,30 @@
 <p>Chapters: 5</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 5.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 5</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 5 chapters, so valid results are 1-5.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=1%20John%201&version=NASB1995" target="_blank">Chapter 1 1 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20John%202&version=NASB1995" target="_blank">Chapter 2 1 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20John%203&version=NASB1995" target="_blank">Chapter 3 1 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20John%204&version=NASB1995" target="_blank">Chapter 4 1 John (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20John%205&version=NASB1995" target="_blank">Chapter 5 1 John (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 5;

--- a/63-2-john.html
+++ b/63-2-john.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>2 John</h1>
+<body><h1>2 John</h1>
 <p><strong>Author:</strong> John</p>
 <p><strong>Date of Writing:</strong> A.D. 85-95</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,26 @@
 <p>Chapters: 1</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 1.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 1</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 1 chapter, so the only valid result is 1.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=2%20John%201&version=NASB1995" target="_blank">Chapter 1 2 John (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 1;

--- a/64-3-john.html
+++ b/64-3-john.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>3 John</h1>
+<body><h1>3 John</h1>
 <p><strong>Author:</strong> John</p>
 <p><strong>Date of Writing:</strong> A.D. 85-95</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,26 @@
 <p>Chapters: 1</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 1.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 1</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 1 chapter, so the only valid result is 1.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=3%20John%201&version=NASB1995" target="_blank">Chapter 1 3 John (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 1;

--- a/65-jude.html
+++ b/65-jude.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Jude</h1>
+<body><h1>Jude</h1>
 <p><strong>Author:</strong> Jude</p>
 <p><strong>Date of Writing:</strong> A.D. 65-80</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,26 @@
 <p>Chapters: 1</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 1.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 1</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 1 chapter, so the only valid result is 1.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Jude%201&version=NASB1995" target="_blank">Chapter 1 Jude (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 1;

--- a/66-revelation.html
+++ b/66-revelation.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #e74c3c; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #c0392b; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Revelation</h1>
+<body><h1>Revelation</h1>
 <p><strong>Author:</strong> John</p>
 <p><strong>Date of Writing:</strong> A.D. 95</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,47 @@
 <p>Chapters: 22</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 22.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 22</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 22 chapters, so valid results are 1-22.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%201&version=NASB1995" target="_blank">Chapter 1 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%202&version=NASB1995" target="_blank">Chapter 2 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%203&version=NASB1995" target="_blank">Chapter 3 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%204&version=NASB1995" target="_blank">Chapter 4 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%205&version=NASB1995" target="_blank">Chapter 5 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%206&version=NASB1995" target="_blank">Chapter 6 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%207&version=NASB1995" target="_blank">Chapter 7 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%208&version=NASB1995" target="_blank">Chapter 8 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%209&version=NASB1995" target="_blank">Chapter 9 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2010&version=NASB1995" target="_blank">Chapter 10 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2011&version=NASB1995" target="_blank">Chapter 11 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2012&version=NASB1995" target="_blank">Chapter 12 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2013&version=NASB1995" target="_blank">Chapter 13 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2014&version=NASB1995" target="_blank">Chapter 14 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2015&version=NASB1995" target="_blank">Chapter 15 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2016&version=NASB1995" target="_blank">Chapter 16 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2017&version=NASB1995" target="_blank">Chapter 17 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2018&version=NASB1995" target="_blank">Chapter 18 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2019&version=NASB1995" target="_blank">Chapter 19 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2020&version=NASB1995" target="_blank">Chapter 20 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2021&version=NASB1995" target="_blank">Chapter 21 Revelation (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Revelation%2022&version=NASB1995" target="_blank">Chapter 22 Revelation (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 22;

--- a/7-judges.html
+++ b/7-judges.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Judges</h1>
+<body><h1>Judges</h1>
 <p><strong>Author:</strong> Unknown</p>
 <p><strong>Date of Writing:</strong> around 1050 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,46 @@
 <p>Chapters: 21</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 21.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 21</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 21 chapters, so valid results are 1-21.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Judges%201&version=NASB1995" target="_blank">Chapter 1 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%202&version=NASB1995" target="_blank">Chapter 2 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%203&version=NASB1995" target="_blank">Chapter 3 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%204&version=NASB1995" target="_blank">Chapter 4 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%205&version=NASB1995" target="_blank">Chapter 5 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%206&version=NASB1995" target="_blank">Chapter 6 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%207&version=NASB1995" target="_blank">Chapter 7 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%208&version=NASB1995" target="_blank">Chapter 8 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%209&version=NASB1995" target="_blank">Chapter 9 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2010&version=NASB1995" target="_blank">Chapter 10 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2011&version=NASB1995" target="_blank">Chapter 11 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2012&version=NASB1995" target="_blank">Chapter 12 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2013&version=NASB1995" target="_blank">Chapter 13 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2014&version=NASB1995" target="_blank">Chapter 14 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2015&version=NASB1995" target="_blank">Chapter 15 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2016&version=NASB1995" target="_blank">Chapter 16 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2017&version=NASB1995" target="_blank">Chapter 17 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2018&version=NASB1995" target="_blank">Chapter 18 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2019&version=NASB1995" target="_blank">Chapter 19 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2020&version=NASB1995" target="_blank">Chapter 20 Judges (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Judges%2021&version=NASB1995" target="_blank">Chapter 21 Judges (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 21;

--- a/8-ruth.html
+++ b/8-ruth.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>Ruth</h1>
+<body><h1>Ruth</h1>
 <p><strong>Author:</strong> Unknown</p>
 <p><strong>Date of Writing:</strong> around 1000 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,29 @@
 <p>Chapters: 4</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 4.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 4</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 4 chapters, so valid results are 1-4.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=Ruth%201&version=NASB1995" target="_blank">Chapter 1 Ruth (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ruth%202&version=NASB1995" target="_blank">Chapter 2 Ruth (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ruth%203&version=NASB1995" target="_blank">Chapter 3 Ruth (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=Ruth%204&version=NASB1995" target="_blank">Chapter 4 Ruth (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 4;

--- a/9-1-samuel.html
+++ b/9-1-samuel.html
@@ -6,12 +6,19 @@
 <style>
   body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; line-height: 1.6; background: #f9f9f9; }
   h1 { color: #2c3e50; }
+  h2 { color: #34495e; border-bottom: 2px solid #3498db; padding-bottom: 0.5rem; }
   button { background-color: #87CEEB; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; margin-top: 1rem; }
   .back { margin-top: 2rem; }
+  .chapter-links { background: white; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin: 2rem 0; }
+  .chapter-links a { color: #2980b9; text-decoration: none; display: inline-block; margin: 0.2rem 0; }
+  .chapter-links a:hover { text-decoration: underline; background-color: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+  .note { font-style: italic; color: #666; margin-bottom: 1rem; }
+  .offline-instructions { background: #f8f9fa; padding: 1rem; border-radius: 5px; margin: 1rem 0; border-left: 4px solid #87CEEB; }
+  .offline-instructions ol { margin: 0.5rem 0; }
+  .offline-instructions li { margin: 0.3rem 0; }
 </style>
 </head>
-<body>
-<h1>1 Samuel</h1>
+<body><h1>1 Samuel</h1>
 <p><strong>Author:</strong> Samuel and others</p>
 <p><strong>Date of Writing:</strong> around 930 B.C.</p>
 <p>This book holds a key place in the biblical story.</p>
@@ -22,8 +29,56 @@
 <p>Chapters: 31</p>
 <button onclick='roll()'>Roll Chapter</button>
 <p id='result'></p>
-<p><em>Offline option:</em> Use any dice combo to generate a number between 1 and 31.</p>
-<p class='back'><a href='index.html'>Back to Index</a></p>
+
+<div class="offline-instructions">
+<p><strong>🎲 Offline Dice Method:</strong></p>
+<ol>
+<li><strong>Roll a D6</strong> and subtract 1 for the first digit of your chapter number</li>
+<li><strong>Roll a D10</strong> (0-9) for the second digit of your chapter number</li>
+<li><strong>Combine the results</strong> to get your chapter (e.g., D6 roll of 3 minus 1 = 2, D10 roll of 7 = Chapter 27)</li>
+<li><strong>If your result is higher than 31</strong>, reroll both dice</li>
+</ol>
+<p><em>This book has 31 chapters, so valid results are 1-31.</em></p>
+</div>
+
+<h2>📖 Fast Chapter Access</h2>
+<div class="chapter-links">
+<p class="note">Chapter links open Bible Gateway in new tab - your dice page stays open!</p>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%201&version=NASB1995" target="_blank">Chapter 1 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%202&version=NASB1995" target="_blank">Chapter 2 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%203&version=NASB1995" target="_blank">Chapter 3 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%204&version=NASB1995" target="_blank">Chapter 4 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%205&version=NASB1995" target="_blank">Chapter 5 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%206&version=NASB1995" target="_blank">Chapter 6 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%207&version=NASB1995" target="_blank">Chapter 7 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%208&version=NASB1995" target="_blank">Chapter 8 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%209&version=NASB1995" target="_blank">Chapter 9 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2010&version=NASB1995" target="_blank">Chapter 10 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2011&version=NASB1995" target="_blank">Chapter 11 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2012&version=NASB1995" target="_blank">Chapter 12 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2013&version=NASB1995" target="_blank">Chapter 13 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2014&version=NASB1995" target="_blank">Chapter 14 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2015&version=NASB1995" target="_blank">Chapter 15 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2016&version=NASB1995" target="_blank">Chapter 16 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2017&version=NASB1995" target="_blank">Chapter 17 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2018&version=NASB1995" target="_blank">Chapter 18 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2019&version=NASB1995" target="_blank">Chapter 19 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2020&version=NASB1995" target="_blank">Chapter 20 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2021&version=NASB1995" target="_blank">Chapter 21 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2022&version=NASB1995" target="_blank">Chapter 22 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2023&version=NASB1995" target="_blank">Chapter 23 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2024&version=NASB1995" target="_blank">Chapter 24 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2025&version=NASB1995" target="_blank">Chapter 25 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2026&version=NASB1995" target="_blank">Chapter 26 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2027&version=NASB1995" target="_blank">Chapter 27 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2028&version=NASB1995" target="_blank">Chapter 28 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2029&version=NASB1995" target="_blank">Chapter 29 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2030&version=NASB1995" target="_blank">Chapter 30 1 Samuel (NASB)</a><br>
+<a href="https://www.biblegateway.com/passage/?search=1%20Samuel%2031&version=NASB1995" target="_blank">Chapter 31 1 Samuel (NASB)</a><br>
+</div>
+
+<p class='back'><a href='index.html'>← Back to 2dice.fun Bible Books</a></p>
+
 <script>
 function roll() {
   var max = 31;


### PR DESCRIPTION
## Summary
- integrate detailed D6+D10 offline dice instructions on every Bible book page
- add full BibleGateway NASB1995 chapter links for all 66 books
- include styling and red/blue accent colors depending on testament

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ecfc9a1608320bbdb6cb0d3626aa9